### PR TITLE
Test api refactor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,7 @@ authors = ["The Servo Project Developers"]
 
 [features]
 default = ["bluetooth"]
-bluetooth = ["blurz", "blurdroid"]
-bluetooth-test = ["blurmock"]
+bluetooth = ["blurz", "blurdroid","blurmock"]
 
 [target.'cfg(target_os = "linux")'.dependencies]
 blurz = { version = "0.2.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,8 @@ authors = ["The Servo Project Developers"]
 
 [features]
 default = ["bluetooth"]
-bluetooth = ["blurz", "blurdroid","blurmock"]
+bluetooth = ["blurz", "blurdroid"]
+bluetooth-test = ["blurmock"]
 
 [target.'cfg(target_os = "linux")'.dependencies]
 blurz = { version = "0.2.0", optional = true }

--- a/src/bluetooth.rs
+++ b/src/bluetooth.rs
@@ -156,6 +156,22 @@ macro_rules! get_inner_and_call(
     };
 );
 
+macro_rules! get_inner_and_call_test_func {
+    ($enum_value: expr, $enum_type: ident, $function_name: ident, $value: expr) => {
+        match $enum_value {
+            &$enum_type::Mock(ref fake) => fake.$function_name($value),
+            _ => Err(Box::from(NOT_SUPPORTED_ERROR)),
+        }
+    };
+
+    ($enum_value: expr, $enum_type: ident, $function_name: ident) => {
+        match $enum_value {
+            &$enum_type::Mock(ref fake) => fake.$function_name(),
+            _ => Err(Box::from(NOT_SUPPORTED_ERROR)),
+        }
+    };
+}
+
 impl BluetoothAdapter {
     #[cfg(all(target_os = "linux", feature = "bluetooth"))]
     pub fn init() -> Result<BluetoothAdapter, Box<Error>> {
@@ -225,10 +241,7 @@ impl BluetoothAdapter {
 
     #[cfg(feature = "bluetooth")]
     pub fn set_name(&self, name: String) -> Result<(), Box<Error>> {
-        match self {
-            &BluetoothAdapter::Mock(ref fake_adapter) => fake_adapter.set_name(name),
-            _ => Err(Box::from(NOT_SUPPORTED_ERROR)),
-        }
+        get_inner_and_call_test_func!(self, BluetoothAdapter, set_name, name)
     }
 
     pub fn get_alias(&self) -> Result<String, Box<Error>> {
@@ -236,11 +249,8 @@ impl BluetoothAdapter {
     }
 
     #[cfg(feature = "bluetooth")]
-    pub fn set_alias(&self, value: String) -> Result<(), Box<Error>> {
-        match self {
-            &BluetoothAdapter::Mock(ref fake_adapter) => fake_adapter.set_alias(value),
-            _ => Err(Box::from(NOT_SUPPORTED_ERROR)),
-        }
+    pub fn set_alias(&self, alias: String) -> Result<(), Box<Error>> {
+        get_inner_and_call_test_func!(self, BluetoothAdapter, set_alias, alias)
     }
 
     pub fn get_class(&self) -> Result<u32, Box<Error>> {
@@ -249,10 +259,7 @@ impl BluetoothAdapter {
 
     #[cfg(feature = "bluetooth")]
     pub fn set_class(&self, class: u32) -> Result<(), Box<Error>> {
-        match self {
-            &BluetoothAdapter::Mock(ref fake_adapter) => fake_adapter.set_class(class),
-            _ => Err(Box::from(NOT_SUPPORTED_ERROR)),
-        }
+        get_inner_and_call_test_func!(self, BluetoothAdapter, set_class, class)
     }
 
     pub fn is_powered(&self) -> Result<bool, Box<Error>> {
@@ -260,11 +267,8 @@ impl BluetoothAdapter {
     }
 
     #[cfg(feature = "bluetooth")]
-    pub fn set_powered(&self, value: bool) -> Result<(), Box<Error>> {
-        match self {
-            &BluetoothAdapter::Mock(ref fake_adapter) => fake_adapter.set_powered(value),
-            _ => Err(Box::from(NOT_SUPPORTED_ERROR)),
-        }
+    pub fn set_powered(&self, powered: bool) -> Result<(), Box<Error>> {
+        get_inner_and_call_test_func!(self, BluetoothAdapter, set_powered, powered)
     }
 
     #[cfg(feature = "bluetooth")]
@@ -276,11 +280,8 @@ impl BluetoothAdapter {
     }
 
     #[cfg(feature = "bluetooth")]
-    pub fn set_present(&self, value: bool) -> Result<(), Box<Error>> {
-        match self {
-            &BluetoothAdapter::Mock(ref fake_adapter) => fake_adapter.set_present(value),
-            _ => Err(Box::from(NOT_SUPPORTED_ERROR)),
-        }
+    pub fn set_present(&self, present: bool) -> Result<(), Box<Error>> {
+        get_inner_and_call_test_func!(self, BluetoothAdapter, set_present, present)
     }
 
     pub fn is_discoverable(&self) -> Result<bool, Box<Error>> {
@@ -288,11 +289,8 @@ impl BluetoothAdapter {
     }
 
     #[cfg(feature = "bluetooth")]
-    pub fn set_discoverable(&self, value: bool) -> Result<(), Box<Error>> {
-        match self {
-            &BluetoothAdapter::Mock(ref fake_adapter) => fake_adapter.set_discoverable(value),
-            _ => Err(Box::from(NOT_SUPPORTED_ERROR)),
-        }
+    pub fn set_discoverable(&self, discoverable: bool) -> Result<(), Box<Error>> {
+        get_inner_and_call_test_func!(self, BluetoothAdapter, set_discoverable, discoverable)
     }
 
     pub fn is_pairable(&self) -> Result<bool, Box<Error>> {
@@ -300,11 +298,8 @@ impl BluetoothAdapter {
     }
 
     #[cfg(feature = "bluetooth")]
-    pub fn set_pairable(&self, value: bool) -> Result<(), Box<Error>> {
-        match self {
-            &BluetoothAdapter::Mock(ref fake_adapter) => fake_adapter.set_pairable(value),
-            _ => Err(Box::from(NOT_SUPPORTED_ERROR)),
-        }
+    pub fn set_pairable(&self, pairable: bool) -> Result<(), Box<Error>> {
+        get_inner_and_call_test_func!(self, BluetoothAdapter, set_pairable, pairable)
     }
 
     pub fn get_pairable_timeout(&self) -> Result<u32, Box<Error>> {
@@ -312,11 +307,8 @@ impl BluetoothAdapter {
     }
 
     #[cfg(feature = "bluetooth")]
-    pub fn set_pairable_timeout(&self, value: u32) -> Result<(), Box<Error>> {
-        match self {
-            &BluetoothAdapter::Mock(ref fake_adapter) => fake_adapter.set_pairable_timeout(value),
-            _ => Err(Box::from(NOT_SUPPORTED_ERROR)),
-        }
+    pub fn set_pairable_timeout(&self, timeout: u32) -> Result<(), Box<Error>> {
+        get_inner_and_call_test_func!(self, BluetoothAdapter, set_pairable_timeout, timeout)
     }
 
     pub fn get_discoverable_timeout(&self) -> Result<u32, Box<Error>> {
@@ -324,11 +316,8 @@ impl BluetoothAdapter {
     }
 
     #[cfg(feature = "bluetooth")]
-    pub fn set_discoverable_timeout(&self, value: u32) -> Result<(), Box<Error>> {
-        match self {
-            &BluetoothAdapter::Mock(ref fake_adapter) => fake_adapter.set_discoverable_timeout(value),
-            _ => Err(Box::from(NOT_SUPPORTED_ERROR)),
-        }
+    pub fn set_discoverable_timeout(&self, timeout: u32) -> Result<(), Box<Error>> {
+        get_inner_and_call_test_func!(self, BluetoothAdapter, set_discoverable_timeout, timeout)
     }
 
     pub fn is_discovering(&self) -> Result<bool, Box<Error>> {
@@ -336,19 +325,13 @@ impl BluetoothAdapter {
     }
 
     #[cfg(feature = "bluetooth")]
-    pub fn set_discovering(&self, is_discovering: bool) -> Result<(), Box<Error>> {
-        match self {
-            &BluetoothAdapter::Mock(ref fake_adapter) => fake_adapter.set_discovering(is_discovering),
-            _ => Err(Box::from(NOT_SUPPORTED_ERROR)),
-        }
+    pub fn set_discovering(&self, discovering: bool) -> Result<(), Box<Error>> {
+        get_inner_and_call_test_func!(self, BluetoothAdapter, set_discovering, discovering)
     }
 
     #[cfg(feature = "bluetooth")]
     pub fn set_can_start_discovery(&self, can_start_discovery: bool) -> Result<(), Box<Error>> {
-        match self {
-            &BluetoothAdapter::Mock(ref fake_adapter) => fake_adapter.set_can_start_discovery(can_start_discovery),
-            _ => Err(Box::from(NOT_SUPPORTED_ERROR)),
-        }
+        get_inner_and_call_test_func!(self, BluetoothAdapter, set_can_start_discovery, can_start_discovery)
     }
 
     #[cfg(feature = "bluetooth")]
@@ -362,10 +345,7 @@ impl BluetoothAdapter {
 
     #[cfg(feature = "bluetooth")]
     pub fn set_uuids(&self, uuids: Vec<String>) -> Result<(), Box<Error>> {
-        match self {
-            &BluetoothAdapter::Mock(ref fake_adapter) => fake_adapter.set_uuids(uuids),
-            _ => Err(Box::from(NOT_SUPPORTED_ERROR)),
-        }
+        get_inner_and_call_test_func!(self, BluetoothAdapter, set_uuids, uuids)
     }
 
     pub fn get_vendor_id_source(&self) -> Result<String, Box<Error>> {
@@ -390,10 +370,7 @@ impl BluetoothAdapter {
 
     #[cfg(feature = "bluetooth")]
     pub fn set_modalias(&self, modalias: String) -> Result<(), Box<Error>> {
-        match self {
-            &BluetoothAdapter::Mock(ref fake_adapter) => fake_adapter.set_modalias(modalias),
-            _ => Err(Box::from(NOT_SUPPORTED_ERROR)),
-        }
+        get_inner_and_call_test_func!(self, BluetoothAdapter, set_modalias, modalias)
     }
 }
 
@@ -473,10 +450,7 @@ impl BluetoothDevice {
 
     #[cfg(feature = "bluetooth")]
     pub fn set_address(&self, address: String) -> Result<(), Box<Error>> {
-        match self {
-            &BluetoothDevice::Mock(ref fake_device) => fake_device.set_address(address),
-            _ => Err(Box::from(NOT_SUPPORTED_ERROR)),
-        }
+        get_inner_and_call_test_func!(self, BluetoothDevice, set_address, address)
     }
 
     pub fn get_name(&self) -> Result<String, Box<Error>> {
@@ -485,10 +459,7 @@ impl BluetoothDevice {
 
     #[cfg(feature = "bluetooth")]
     pub fn set_name(&self, name: String) -> Result<(), Box<Error>> {
-        match self {
-            &BluetoothDevice::Mock(ref fake_device) => fake_device.set_name(name),
-            _ => Err(Box::from(NOT_SUPPORTED_ERROR)),
-        }
+        get_inner_and_call_test_func!(self, BluetoothDevice, set_name, name)
     }
 
     pub fn get_icon(&self) -> Result<String, Box<Error>> {
@@ -505,10 +476,7 @@ impl BluetoothDevice {
 
     #[cfg(feature = "bluetooth")]
     pub fn set_appearance(&self, appearance: u16) -> Result<(), Box<Error>> {
-        match self {
-            &BluetoothDevice::Mock(ref fake_device) => fake_device.set_appearance(appearance),
-            _ => Err(Box::from(NOT_SUPPORTED_ERROR)),
-        }
+        get_inner_and_call_test_func!(self, BluetoothDevice, set_appearance, appearance)
     }
 
     pub fn get_uuids(&self) -> Result<Vec<String>, Box<Error>> {
@@ -517,10 +485,7 @@ impl BluetoothDevice {
 
     #[cfg(feature = "bluetooth")]
     pub fn set_uuids(&self, uuids: Vec<String>) -> Result<(), Box<Error>> {
-        match self {
-            &BluetoothDevice::Mock(ref fake_device) => fake_device.set_uuids(uuids),
-            _ => Err(Box::from(NOT_SUPPORTED_ERROR)),
-        }
+        get_inner_and_call_test_func!(self, BluetoothDevice, set_uuids, uuids)
     }
 
     pub fn is_paired(&self) -> Result<bool, Box<Error>> {
@@ -533,18 +498,12 @@ impl BluetoothDevice {
 
     #[cfg(feature = "bluetooth")]
     pub fn is_connectable(&self) -> Result<bool, Box<Error>> {
-        match self {
-            &BluetoothDevice::Mock(ref fake_device) => fake_device.is_connectable(),
-            _ => Err(Box::from(NOT_SUPPORTED_ERROR)),
-        }
+        get_inner_and_call_test_func!(self, BluetoothDevice, is_connectable)
     }
 
     #[cfg(feature = "bluetooth")]
     pub fn set_connectable(&self, connectable: bool) -> Result<(), Box<Error>> {
-        match self {
-            &BluetoothDevice::Mock(ref fake_device) => fake_device.set_connectable(connectable),
-            _ => Err(Box::from(NOT_SUPPORTED_ERROR)),
-        }
+        get_inner_and_call_test_func!(self, BluetoothDevice, set_connectable, connectable)
     }
 
     pub fn is_trusted(&self) -> Result<bool, Box<Error>> {
@@ -561,10 +520,7 @@ impl BluetoothDevice {
 
     #[cfg(feature = "bluetooth")]
     pub fn set_alias(&self, alias: String) -> Result<(), Box<Error>> {
-        match self {
-            &BluetoothDevice::Mock(ref fake_device) => fake_device.set_alias(alias),
-            _ => Err(Box::from(NOT_SUPPORTED_ERROR)),
-        }
+        get_inner_and_call_test_func!(self, BluetoothDevice, set_alias, alias)
     }
 
     pub fn is_legacy_pairing(&self) -> Result<bool, Box<Error>> {
@@ -597,14 +553,6 @@ impl BluetoothDevice {
 
     pub fn get_tx_power(&self) -> Result<i16, Box<Error>> {
         get_inner_and_call!(self, BluetoothDevice, get_tx_power)
-    }
-
-    #[cfg(feature = "bluetooth")]
-    pub fn set_tx_power(&self, tx_power: i16) -> Result<(), Box<Error>> {
-        match self {
-            &BluetoothDevice::Mock(ref fake_device) => fake_device.set_tx_power(tx_power),
-            _ => Err(Box::from(NOT_SUPPORTED_ERROR)),
-        }
     }
 
     pub fn get_gatt_services(&self) -> Result<Vec<BluetoothGATTService>, Box<Error>> {
@@ -680,11 +628,8 @@ impl BluetoothGATTService {
     }
 
     #[cfg(feature = "bluetooth")]
-    pub fn set_primary(&self, value: bool) -> Result<(), Box<Error>> {
-        match self {
-            &BluetoothGATTService::Mock(ref fake_service) => fake_service.set_is_primary(value),
-            _ => Err(Box::from(NOT_SUPPORTED_ERROR)),
-        }
+    pub fn set_primary(&self, primary: bool) -> Result<(), Box<Error>> {
+        get_inner_and_call_test_func!(self, BluetoothGATTService, set_is_primary, primary)
     }
 
     pub fn get_includes(&self) -> Result<Vec<BluetoothGATTService>, Box<Error>> {
@@ -731,10 +676,7 @@ impl BluetoothGATTCharacteristic {
 
     #[cfg(feature = "bluetooth")]
     pub fn set_uuid(&self, uuid: String) -> Result<(), Box<Error>> {
-        match self {
-            &BluetoothGATTCharacteristic::Mock(ref fake_characteristic) => fake_characteristic.set_uuid(uuid),
-            _ => Err(Box::from(NOT_SUPPORTED_ERROR)),
-        }
+        get_inner_and_call_test_func!(self, BluetoothGATTCharacteristic, set_uuid, uuid)
     }
 
     pub fn get_value(&self) -> Result<Vec<u8>, Box<Error>> {

--- a/src/bluetooth.rs
+++ b/src/bluetooth.rs
@@ -159,13 +159,6 @@ macro_rules! get_inner_and_call(
 
 #[cfg(feature = "bluetooth-test")]
 macro_rules! get_inner_and_call_test_func {
-    ($enum_value: expr, $enum_type: ident, set_id, $value: expr) => {
-        match $enum_value {
-            &$enum_type::Mock(ref fake) => fake.set_id($value),
-            _ => (),
-        }
-    };
-
     ($enum_value: expr, $enum_type: ident, $function_name: ident, $value: expr) => {
         match $enum_value {
             &$enum_type::Mock(ref fake) => fake.$function_name($value),
@@ -211,7 +204,10 @@ impl BluetoothAdapter {
 
     #[cfg(feature = "bluetooth-test")]
     pub fn set_id(&self, id: String) {
-        get_inner_and_call_test_func!(self, BluetoothAdapter, set_id, id)
+        match self {
+            &BluetoothAdapter::Mock(ref fake_adapter) => fake_adapter.set_id(id),
+            _ => (),
+        }
     }
 
     pub fn get_devices(&self) -> Result<Vec<BluetoothDevice>, Box<Error>> {
@@ -440,7 +436,10 @@ impl BluetoothDevice {
 
     #[cfg(feature = "bluetooth-test")]
     pub fn set_id(&self, id: String) {
-        get_inner_and_call_test_func!(self, BluetoothDevice, set_id, id)
+        match self {
+            &BluetoothDevice::Mock(ref fake_adapter) => fake_adapter.set_id(id),
+            _ => (),
+        }
     }
 
     pub fn get_address(&self) -> Result<String, Box<Error>> {

--- a/src/bluetooth.rs
+++ b/src/bluetooth.rs
@@ -632,10 +632,9 @@ impl BluetoothGATTService {
         get_inner_and_call_test_func!(self, BluetoothGATTService, set_is_primary, primary)
     }
 
-    pub fn get_includes(&self) -> Result<Vec<BluetoothGATTService>, Box<Error>> {
-        /*let services = try!(self.get_gatt_service().get_includes());
-        Ok(services.into_iter().map(|service| BluetoothGATTService::create_service(self.get_device(), service)).collect())*/
-        Err(Box::from(NOT_SUPPORTED_ERROR))
+    pub fn get_includes(&self, device: BluetoothDevice) -> Result<Vec<BluetoothGATTService>, Box<Error>> {
+        let services = try!(get_inner_and_call!(self, BluetoothGATTService, get_includes));
+        Ok(services.into_iter().map(|service| BluetoothGATTService::create_service(device.clone(), service)).collect())
     }
 
     pub fn get_gatt_characteristics(&self) -> Result<Vec<BluetoothGATTCharacteristic>, Box<Error>> {

--- a/src/bluetooth.rs
+++ b/src/bluetooth.rs
@@ -333,6 +333,11 @@ impl BluetoothAdapter {
         get_inner_and_call_test_func!(self, BluetoothAdapter, set_can_start_discovery, can_start_discovery)
     }
 
+    #[cfg(feature = "bluetooth-test")]
+    pub fn set_can_stop_discovery(&self, can_stop_discovery: bool) -> Result<(), Box<Error>> {
+        get_inner_and_call_test_func!(self, BluetoothAdapter, set_can_stop_discovery, can_stop_discovery)
+    }
+
     pub fn create_discovery_session(&self) -> Result<BluetoothDiscoverySession, Box<Error>> {
         BluetoothDiscoverySession::create_session(self.clone())
     }
@@ -369,6 +374,16 @@ impl BluetoothAdapter {
     #[cfg(feature = "bluetooth-test")]
     pub fn set_modalias(&self, modalias: String) -> Result<(), Box<Error>> {
         get_inner_and_call_test_func!(self, BluetoothAdapter, set_modalias, modalias)
+    }
+
+    #[cfg(feature = "bluetooth-test")]
+    pub fn get_ad_datas(&self) -> Result<Vec<String>, Box<Error>> {
+        get_inner_and_call_test_func!(self, BluetoothAdapter, get_ad_datas)
+    }
+
+    #[cfg(feature = "bluetooth-test")]
+    pub fn set_ad_datas(&self, ad_datas: Vec<String>) -> Result<(), Box<Error>> {
+        get_inner_and_call_test_func!(self, BluetoothAdapter, set_ad_datas, ad_datas)
     }
 }
 
@@ -464,8 +479,18 @@ impl BluetoothDevice {
         get_inner_and_call!(self, BluetoothDevice, get_icon)
     }
 
+    #[cfg(feature = "bluetooth-test")]
+    pub fn set_icon(&self, icon: String) -> Result<(), Box<Error>> {
+        get_inner_and_call_test_func!(self, BluetoothDevice, set_icon, icon)
+    }
+
     pub fn get_class(&self) -> Result<u32, Box<Error>> {
         get_inner_and_call!(self, BluetoothDevice, get_class)
+    }
+
+    #[cfg(feature = "bluetooth-test")]
+    pub fn set_class(&self, class: u32) -> Result<(), Box<Error>> {
+        get_inner_and_call_test_func!(self, BluetoothDevice, set_class, class)
     }
 
     pub fn get_appearance(&self) -> Result<u16, Box<Error>> {
@@ -490,8 +515,18 @@ impl BluetoothDevice {
         get_inner_and_call!(self, BluetoothDevice, is_paired)
     }
 
+    #[cfg(feature = "bluetooth-test")]
+    pub fn set_paired(&self, paired: bool) -> Result<(), Box<Error>> {
+        get_inner_and_call_test_func!(self, BluetoothDevice, set_paired, paired)
+    }
+
     pub fn is_connected(&self) -> Result<bool, Box<Error>> {
         get_inner_and_call!(self, BluetoothDevice, is_connected)
+    }
+
+    #[cfg(feature = "bluetooth-test")]
+    pub fn set_connected(&self, connected: bool) -> Result<(), Box<Error>> {
+        get_inner_and_call_test_func!(self, BluetoothDevice, set_connected, connected)
     }
 
     #[cfg(feature = "bluetooth-test")]
@@ -508,8 +543,18 @@ impl BluetoothDevice {
         get_inner_and_call!(self, BluetoothDevice, is_trusted)
     }
 
+    #[cfg(feature = "bluetooth-test")]
+    pub fn set_trusted(&self, trusted: bool) -> Result<(), Box<Error>> {
+        get_inner_and_call_test_func!(self, BluetoothDevice, set_trusted, trusted)
+    }
+
     pub fn is_blocked(&self) -> Result<bool, Box<Error>> {
         get_inner_and_call!(self, BluetoothDevice, is_blocked)
+    }
+
+    #[cfg(feature = "bluetooth-test")]
+    pub fn set_blocked(&self, blocked: bool) -> Result<(), Box<Error>> {
+        get_inner_and_call_test_func!(self, BluetoothDevice, set_blocked, blocked)
     }
 
     pub fn get_alias(&self) -> Result<String, Box<Error>> {
@@ -523,6 +568,11 @@ impl BluetoothDevice {
 
     pub fn is_legacy_pairing(&self) -> Result<bool, Box<Error>> {
         get_inner_and_call!(self, BluetoothDevice, is_legacy_pairing)
+    }
+
+    #[cfg(feature = "bluetooth-test")]
+    pub fn set_legacy_pairing(&self, legacy_pairing: bool) -> Result<(), Box<Error>> {
+        get_inner_and_call_test_func!(self, BluetoothDevice, set_legacy_pairing, legacy_pairing)
     }
 
     pub fn get_vendor_id_source(&self) -> Result<String, Box<Error>> {
@@ -545,12 +595,27 @@ impl BluetoothDevice {
         get_inner_and_call!(self, BluetoothDevice, get_modalias)
     }
 
+    #[cfg(feature = "bluetooth-test")]
+    pub fn set_modalias(&self, modalias: String) -> Result<(), Box<Error>> {
+        get_inner_and_call_test_func!(self, BluetoothDevice, set_modalias, modalias)
+    }
+
     pub fn get_rssi(&self) -> Result<i16, Box<Error>> {
         get_inner_and_call!(self, BluetoothDevice, get_rssi)
     }
 
+    #[cfg(feature = "bluetooth-test")]
+    pub fn set_rssi(&self, rssi: i16) -> Result<(), Box<Error>> {
+        get_inner_and_call_test_func!(self, BluetoothDevice, set_rssi, rssi)
+    }
+
     pub fn get_tx_power(&self) -> Result<i16, Box<Error>> {
         get_inner_and_call!(self, BluetoothDevice, get_tx_power)
+    }
+
+    #[cfg(feature = "bluetooth-test")]
+    pub fn set_tx_power(&self, tx_power: i16) -> Result<(), Box<Error>> {
+        get_inner_and_call_test_func!(self, BluetoothDevice, set_tx_power, tx_power)
     }
 
     pub fn get_gatt_services(&self) -> Result<Vec<BluetoothGATTService>, Box<Error>> {
@@ -609,6 +674,14 @@ impl BluetoothGATTService {
         get_inner_and_call!(self, BluetoothGATTService, get_id)
     }
 
+    #[cfg(feature = "bluetooth-test")]
+    pub fn set_id(&self, id: String) {
+        match self {
+            &BluetoothGATTService::Mock(ref fake_service) => fake_service.set_id(id),
+            _ => (),
+        }
+    }
+
     pub fn get_uuid(&self) -> Result<String, Box<Error>> {
         get_inner_and_call!(self, BluetoothGATTService, get_uuid)
     }
@@ -664,6 +737,14 @@ impl BluetoothGATTCharacteristic {
         get_inner_and_call!(self, BluetoothGATTCharacteristic, get_id)
     }
 
+    #[cfg(feature = "bluetooth-test")]
+    pub fn set_id(&self, id: String) {
+        match self {
+            &BluetoothGATTCharacteristic::Mock(ref fake_characteristic) => fake_characteristic.set_id(id),
+            _ => (),
+        }
+    }
+
     pub fn get_uuid(&self) -> Result<String, Box<Error>> {
         get_inner_and_call!(self, BluetoothGATTCharacteristic, get_uuid)
     }
@@ -677,12 +758,27 @@ impl BluetoothGATTCharacteristic {
         get_inner_and_call!(self, BluetoothGATTCharacteristic, get_value)
     }
 
+    #[cfg(feature = "bluetooth-test")]
+    pub fn set_value(&self, value: Vec<u8>) -> Result<(), Box<Error>> {
+        get_inner_and_call_test_func!(self, BluetoothGATTCharacteristic, set_value, value)
+    }
+
     pub fn is_notifying(&self) -> Result<bool, Box<Error>> {
         get_inner_and_call!(self, BluetoothGATTCharacteristic, is_notifying)
     }
 
+    #[cfg(feature = "bluetooth-test")]
+    pub fn set_notifying(&self, notifying: bool) -> Result<(), Box<Error>> {
+        get_inner_and_call_test_func!(self, BluetoothGATTCharacteristic, set_notifying, notifying)
+    }
+
     pub fn get_flags(&self) -> Result<Vec<String>, Box<Error>> {
         get_inner_and_call!(self, BluetoothGATTCharacteristic, get_flags)
+    }
+
+    #[cfg(feature = "bluetooth-test")]
+    pub fn set_flags(&self, flags: Vec<String>) -> Result<(), Box<Error>> {
+        get_inner_and_call_test_func!(self, BluetoothGATTCharacteristic, set_flags, flags)
     }
 
     pub fn get_gatt_descriptors(&self) -> Result<Vec<BluetoothGATTDescriptor>, Box<Error>> {
@@ -733,16 +829,39 @@ impl BluetoothGATTDescriptor {
         get_inner_and_call!(self, BluetoothGATTDescriptor, get_id)
     }
 
+    #[cfg(feature = "bluetooth-test")]
+    pub fn set_id(&self, id: String) {
+        match self {
+            &BluetoothGATTDescriptor::Mock(ref fake_descriptor) => fake_descriptor.set_id(id),
+            _ => (),
+        }
+    }
+
     pub fn get_uuid(&self) -> Result<String, Box<Error>> {
         get_inner_and_call!(self, BluetoothGATTDescriptor, get_uuid)
+    }
+
+    #[cfg(feature = "bluetooth-test")]
+    pub fn set_uuid(&self, uuid: String) -> Result<(), Box<Error>> {
+        get_inner_and_call_test_func!(self, BluetoothGATTDescriptor, set_uuid, uuid)
     }
 
     pub fn get_value(&self) -> Result<Vec<u8>, Box<Error>> {
         get_inner_and_call!(self, BluetoothGATTDescriptor, get_value)
     }
 
+    #[cfg(feature = "bluetooth-test")]
+    pub fn set_value(&self, value: Vec<u8>) -> Result<(), Box<Error>> {
+        get_inner_and_call_test_func!(self, BluetoothGATTDescriptor, set_value, value)
+    }
+
     pub fn get_flags(&self) -> Result<Vec<String>, Box<Error>> {
         get_inner_and_call!(self, BluetoothGATTDescriptor, get_flags)
+    }
+
+    #[cfg(feature = "bluetooth-test")]
+    pub fn set_flags(&self, flags: Vec<String>) -> Result<(), Box<Error>> {
+        get_inner_and_call_test_func!(self, BluetoothGATTDescriptor, set_flags, flags)
     }
 
     pub fn read_value(&self) -> Result<Vec<u8>, Box<Error>> {

--- a/src/bluetooth.rs
+++ b/src/bluetooth.rs
@@ -54,6 +54,7 @@ use blurmock::fake_discovery_session::FakeBluetoothDiscoverySession;
 use std::sync::Arc;
 use std::error::Error;
 
+#[cfg(feature = "bluetooth-test")]
 const NOT_SUPPORTED_ERROR: &'static str = "Error! Not supported function!";
 
 #[derive(Clone, Debug)]
@@ -156,7 +157,15 @@ macro_rules! get_inner_and_call(
     };
 );
 
+#[cfg(feature = "bluetooth-test")]
 macro_rules! get_inner_and_call_test_func {
+    ($enum_value: expr, $enum_type: ident, set_id, $value: expr) => {
+        match $enum_value {
+            &$enum_type::Mock(ref fake) => fake.set_id($value),
+            _ => (),
+        }
+    };
+
     ($enum_value: expr, $enum_type: ident, $function_name: ident, $value: expr) => {
         match $enum_value {
             &$enum_type::Mock(ref fake) => fake.$function_name($value),
@@ -202,10 +211,7 @@ impl BluetoothAdapter {
 
     #[cfg(feature = "bluetooth-test")]
     pub fn set_id(&self, id: String) {
-        match self {
-            &BluetoothAdapter::Mock(ref fake_adapter) => fake_adapter.set_id(id),
-            _ => (),
-        }
+        get_inner_and_call_test_func!(self, BluetoothAdapter, set_id, id)
     }
 
     pub fn get_devices(&self) -> Result<Vec<BluetoothDevice>, Box<Error>> {
@@ -273,10 +279,7 @@ impl BluetoothAdapter {
 
     #[cfg(feature = "bluetooth-test")]
     pub fn is_present(&self) -> Result<bool, Box<Error>> {
-        match self {
-            &BluetoothAdapter::Mock(ref fake_adapter) => fake_adapter.is_present(),
-            _ => Err(Box::from(NOT_SUPPORTED_ERROR)),
-        }
+        get_inner_and_call_test_func!(self, BluetoothAdapter, is_present)
     }
 
     #[cfg(feature = "bluetooth-test")]
@@ -334,7 +337,6 @@ impl BluetoothAdapter {
         get_inner_and_call_test_func!(self, BluetoothAdapter, set_can_start_discovery, can_start_discovery)
     }
 
-    #[cfg(feature = "bluetooth-test")]
     pub fn create_discovery_session(&self) -> Result<BluetoothDiscoverySession, Box<Error>> {
         BluetoothDiscoverySession::create_session(self.clone())
     }
@@ -438,10 +440,7 @@ impl BluetoothDevice {
 
     #[cfg(feature = "bluetooth-test")]
     pub fn set_id(&self, id: String) {
-        match self {
-            &BluetoothDevice::Mock(ref fake_device) => fake_device.set_id(id),
-            _ => (),
-        }
+        get_inner_and_call_test_func!(self, BluetoothDevice, set_id, id)
     }
 
     pub fn get_address(&self) -> Result<String, Box<Error>> {
@@ -617,10 +616,7 @@ impl BluetoothGATTService {
 
     #[cfg(feature = "bluetooth-test")]
     pub fn set_uuid(&self, uuid: String) -> Result<(), Box<Error>> {
-        match self {
-            &BluetoothGATTService::Mock(ref fake_service) => fake_service.set_uuid(uuid),
-            _ => Err(Box::from(NOT_SUPPORTED_ERROR)),
-        }
+        get_inner_and_call_test_func!(self, BluetoothGATTService, set_uuid, uuid)
     }
 
     pub fn is_primary(&self) -> Result<bool, Box<Error>> {

--- a/src/bluetooth.rs
+++ b/src/bluetooth.rs
@@ -6,191 +6,188 @@
 use blurz::bluetooth_adapter::BluetoothAdapter as BluetoothAdapterBluez;
 #[cfg(all(target_os = "android", feature = "bluetooth"))]
 use blurdroid::bluetooth_adapter::Adapter as BluetoothAdapterAndroid;
-#[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"), feature = "bluetooth-test")))]
+#[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
 use empty::BluetoothAdapter as BluetoothAdapterEmpty;
-#[cfg(feature = "bluetooth-test")]
+#[cfg(feature = "bluetooth")]
 use blurmock::fake_adapter::FakeBluetoothAdapter;
 #[cfg(all(target_os = "linux", feature = "bluetooth"))]
 use blurz::bluetooth_device::BluetoothDevice as BluetoothDeviceBluez;
 #[cfg(all(target_os = "android", feature = "bluetooth"))]
 use blurdroid::bluetooth_device::Device as BluetoothDeviceAndroid;
-#[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"), feature = "bluetooth-test")))]
+#[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
 use empty::BluetoothDevice as BluetoothDeviceEmpty;
-#[cfg(feature = "bluetooth-test")]
+#[cfg(feature = "bluetooth")]
 use blurmock::fake_device::FakeBluetoothDevice;
 #[cfg(all(target_os = "linux", feature = "bluetooth"))]
 use blurz::bluetooth_gatt_characteristic::BluetoothGATTCharacteristic as BluetoothGATTCharacteristicBluez;
 #[cfg(all(target_os = "android", feature = "bluetooth"))]
 use blurdroid::bluetooth_gatt_characteristic::Characteristic as BluetoothGATTCharacteristicAndroid;
-#[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"), feature = "bluetooth-test")))]
+#[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
 use empty::BluetoothGATTCharacteristic as BluetoothGATTCharacteristicEmpty;
-#[cfg(feature = "bluetooth-test")]
+#[cfg(feature = "bluetooth")]
 use blurmock::fake_characteristic::FakeBluetoothGATTCharacteristic;
 #[cfg(all(target_os = "linux", feature = "bluetooth"))]
 use blurz::bluetooth_gatt_descriptor::BluetoothGATTDescriptor as BluetoothGATTDescriptorBluez;
 #[cfg(all(target_os = "android", feature = "bluetooth"))]
 use blurdroid::bluetooth_gatt_descriptor::Descriptor as BluetoothGATTDescriptorAndroid;
-#[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"), feature = "bluetooth-test")))]
+#[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
 use empty::BluetoothGATTDescriptor as BluetoothGATTDescriptorEmpty;
-#[cfg(feature = "bluetooth-test")]
+#[cfg(feature = "bluetooth")]
 use blurmock::fake_descriptor::FakeBluetoothGATTDescriptor;
 #[cfg(all(target_os = "linux", feature = "bluetooth"))]
 use blurz::bluetooth_gatt_service::BluetoothGATTService as BluetoothGATTServiceBluez;
 #[cfg(all(target_os = "android", feature = "bluetooth"))]
 use blurdroid::bluetooth_gatt_service::Service as BluetoothGATTServiceAndroid;
-#[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"), feature = "bluetooth-test")))]
+#[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
 use empty::BluetoothGATTService as BluetoothGATTServiceEmpty;
-#[cfg(feature = "bluetooth-test")]
+#[cfg(feature = "bluetooth")]
 use blurmock::fake_service::FakeBluetoothGATTService;
 #[cfg(all(target_os = "linux", feature = "bluetooth"))]
 use blurz::bluetooth_discovery_session::BluetoothDiscoverySession as BluetoothDiscoverySessionBluez;
 #[cfg(all(target_os = "android", feature = "bluetooth"))]
 use blurdroid::bluetooth_discovery_session::DiscoverySession as BluetoothDiscoverySessionAndroid;
-#[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"), feature = "bluetooth-test")))]
+#[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
 use empty::BluetoothDiscoverySession as BluetoothDiscoverySessionEmpty;
-#[cfg(feature = "bluetooth-test")]
+#[cfg(feature = "bluetooth")]
 use blurmock::fake_discovery_session::FakeBluetoothDiscoverySession;
 
-use std::cell::RefCell;
 use std::sync::Arc;
 use std::error::Error;
 
+const NOT_SUPPORTED_ERROR: &'static str = "Error! Not supported function!";
+
 #[derive(Clone, Debug)]
-pub struct BluetoothAdapter {
+pub enum BluetoothAdapter {
     #[cfg(all(target_os = "linux", feature = "bluetooth"))]
-    adapter: Arc<BluetoothAdapterBluez>,
+    Bluez(Arc<BluetoothAdapterBluez>),
     #[cfg(all(target_os = "android", feature = "bluetooth"))]
-    adapter: Arc<BluetoothAdapterAndroid>,
-    #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"), feature = "bluetooth-test")))]
-    adapter: Arc<BluetoothAdapterEmpty>,
-    #[cfg(feature = "bluetooth-test")]
-    adapter: Arc<FakeBluetoothAdapter>,
+    Android(Arc<BluetoothAdapterAndroid>),
+    #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+    Empty(Arc<BluetoothAdapterEmpty>),
+    #[cfg(feature = "bluetooth")]
+    Mock(Arc<FakeBluetoothAdapter>),
 }
 
 #[derive(Debug)]
-pub struct BluetoothDiscoverySession {
-    adapter: RefCell<BluetoothAdapter>,
+pub enum BluetoothDiscoverySession {
     #[cfg(all(target_os = "linux", feature = "bluetooth"))]
-    session: Arc<BluetoothDiscoverySessionBluez>,
+    Bluez(Arc<BluetoothDiscoverySessionBluez>),
     #[cfg(all(target_os = "android", feature = "bluetooth"))]
-    session: Arc<BluetoothDiscoverySessionAndroid>,
-    #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"), feature = "bluetooth-test")))]
-    session: Arc<BluetoothDiscoverySessionEmpty>,
-    #[cfg(feature = "bluetooth-test")]
-    session: Arc<FakeBluetoothDiscoverySession>,
+    Android(Arc<BluetoothDiscoverySessionAndroid>),
+    #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+    Empty(Arc<BluetoothDiscoverySessionEmpty>),
+    #[cfg(feature = "bluetooth")]
+    Mock(Arc<FakeBluetoothDiscoverySession>),
 }
 
 #[derive(Clone, Debug)]
-pub struct BluetoothDevice {
-    adapter: RefCell<BluetoothAdapter>,
+pub enum BluetoothDevice {
     #[cfg(all(target_os = "linux", feature = "bluetooth"))]
-    device: Arc<BluetoothDeviceBluez>,
+    Bluez(Arc<BluetoothDeviceBluez>),
     #[cfg(all(target_os = "android", feature = "bluetooth"))]
-    device: Arc<BluetoothDeviceAndroid>,
-    #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"), feature = "bluetooth-test")))]
-    device: Arc<BluetoothDeviceEmpty>,
-    #[cfg(feature = "bluetooth-test")]
-    device: Arc<FakeBluetoothDevice>,
+    Android(Arc<BluetoothDeviceAndroid>),
+    #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+    Empty(Arc<BluetoothDeviceEmpty>),
+    #[cfg(feature = "bluetooth")]
+    Mock(Arc<FakeBluetoothDevice>),
 }
 
 #[derive(Clone, Debug)]
-pub struct BluetoothGATTService {
-    device: RefCell<BluetoothDevice>,
+pub enum BluetoothGATTService {
     #[cfg(all(target_os = "linux", feature = "bluetooth"))]
-    gatt_service: Arc<BluetoothGATTServiceBluez>,
+    Bluez(Arc<BluetoothGATTServiceBluez>),
     #[cfg(all(target_os = "android", feature = "bluetooth"))]
-    gatt_service: Arc<BluetoothGATTServiceAndroid>,
-    #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"), feature = "bluetooth-test")))]
-    gatt_service: Arc<BluetoothGATTServiceEmpty>,
-    #[cfg(feature = "bluetooth-test")]
-    gatt_service: Arc<FakeBluetoothGATTService>,
+    Android(Arc<BluetoothGATTServiceAndroid>),
+    #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+    Empty(Arc<BluetoothGATTServiceEmpty>),
+    #[cfg(feature = "bluetooth")]
+    Mock(Arc<FakeBluetoothGATTService>),
 }
 
 #[derive(Clone, Debug)]
-pub struct BluetoothGATTCharacteristic {
-    service: RefCell<BluetoothGATTService>,
+pub enum BluetoothGATTCharacteristic {
     #[cfg(all(target_os = "linux", feature = "bluetooth"))]
-    gatt_characteristic: Arc<BluetoothGATTCharacteristicBluez>,
+    Bluez(Arc<BluetoothGATTCharacteristicBluez>),
     #[cfg(all(target_os = "android", feature = "bluetooth"))]
-    gatt_characteristic: Arc<BluetoothGATTCharacteristicAndroid>,
-    #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"), feature = "bluetooth-test")))]
-    gatt_characteristic: Arc<BluetoothGATTCharacteristicEmpty>,
-    #[cfg(feature = "bluetooth-test")]
-    gatt_characteristic: Arc<FakeBluetoothGATTCharacteristic>,
+    Android(Arc<BluetoothGATTCharacteristicAndroid>),
+    #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+    Empty(Arc<BluetoothGATTCharacteristicEmpty>),
+    #[cfg(feature = "bluetooth")]
+    Mock(Arc<FakeBluetoothGATTCharacteristic>),
 }
 
 #[derive(Clone, Debug)]
-pub struct BluetoothGATTDescriptor {
-    characteristic: RefCell<BluetoothGATTCharacteristic>,
+pub enum BluetoothGATTDescriptor {
     #[cfg(all(target_os = "linux", feature = "bluetooth"))]
-    gatt_descriptor: Arc<BluetoothGATTDescriptorBluez>,
+    Bluez(Arc<BluetoothGATTDescriptorBluez>),
     #[cfg(all(target_os = "android", feature = "bluetooth"))]
-    gatt_descriptor: Arc<BluetoothGATTDescriptorAndroid>,
-    #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"), feature = "bluetooth-test")))]
-    gatt_descriptor: Arc<BluetoothGATTDescriptorEmpty>,
-    #[cfg(feature = "bluetooth-test")]
-    gatt_descriptor: Arc<FakeBluetoothGATTDescriptor>,
+    Android(Arc<BluetoothGATTDescriptorAndroid>),
+    #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+    Empty(Arc<BluetoothGATTDescriptorEmpty>),
+    #[cfg(feature = "bluetooth")]
+    Mock(Arc<FakeBluetoothGATTDescriptor>),
 }
 
 impl BluetoothAdapter {
     #[cfg(all(target_os = "linux", feature = "bluetooth"))]
     pub fn init() -> Result<BluetoothAdapter, Box<Error>> {
         let bluez_adapter = try!(BluetoothAdapterBluez::init());
-        Ok(BluetoothAdapter {adapter: Arc::new(bluez_adapter)})
+        Ok(BluetoothAdapter::Bluez(Arc::new(bluez_adapter)))
     }
 
     #[cfg(all(target_os = "android", feature = "bluetooth"))]
     pub fn init() -> Result<BluetoothAdapter, Box<Error>> {
         let blurdroid_adapter = try!(BluetoothAdapterAndroid::get_adapter());
-        Ok(BluetoothAdapter {adapter: Arc::new(blurdroid_adapter)})
+        Ok(BluetoothAdapter::Android(Arc::new(blurdroid_adapter)))
     }
 
-    #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"), feature = "bluetooth-test")))]
+    #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
     pub fn init() -> Result<BluetoothAdapter, Box<Error>> {
         let adapter = try!(BluetoothAdapterEmpty::init());
-        Ok(BluetoothAdapter {adapter: Arc::new(adapter)})
+        Ok(BluetoothAdapter::Empty(Arc::new(adapter)))
     }
 
-    #[cfg(feature = "bluetooth-test")]
-    pub fn init() -> Result<BluetoothAdapter, Box<Error>> {
-        Ok(BluetoothAdapter{adapter: FakeBluetoothAdapter::new_empty()})
-    }
-
-    #[cfg(all(target_os = "linux", feature = "bluetooth"))]
-    fn get_adapter(&self) -> Arc<BluetoothAdapterBluez> {
-        self.adapter.clone()
-    }
-
-    #[cfg(all(target_os = "android", feature = "bluetooth"))]
-    fn get_adapter(&self) -> Arc<BluetoothAdapterAndroid> {
-        self.adapter.clone()
-    }
-
-    #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"), feature = "bluetooth-test")))]
-    fn get_adapter(&self) -> Arc<BluetoothAdapterEmpty> {
-        self.adapter.clone()
-    }
-
-    #[cfg(feature = "bluetooth-test")]
-    fn get_adapter(&self) -> Arc<FakeBluetoothAdapter> {
-        self.adapter.clone()
+    #[cfg(feature = "bluetooth")]
+    pub fn init_mock() -> Result<BluetoothAdapter, Box<Error>> {
+        Ok(BluetoothAdapter::Mock(FakeBluetoothAdapter::new_empty()))
     }
 
     pub fn get_id(&self) -> String {
-        self.get_adapter().get_id()
+        match self {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            &BluetoothAdapter::Bluez(ref bluez_adapter) => bluez_adapter.get_id(),
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            &BluetoothAdapter::Android(ref android_adapter) => android_adapter.get_id(),
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            &BluetoothAdapter::Empty(ref adapter) => adapter.get_id(),
+            #[cfg(feature = "bluetooth")]
+            &BluetoothAdapter::Mock(ref fake_adapter) => fake_adapter.get_id(),
+        }
     }
 
-    #[cfg(feature = "bluetooth-test")]
+    #[cfg(feature = "bluetooth")]
     pub fn set_id(&self, id: String) {
-        self.get_adapter().set_id(id)
+        match self {
+            &BluetoothAdapter::Mock(ref fake_adapter) => fake_adapter.set_id(id),
+            _ => (),
+        }
     }
 
     pub fn get_devices(&self) -> Result<Vec<BluetoothDevice>, Box<Error>> {
-        let device_list = try!(self.get_adapter().get_device_list());
+        let device_list = match self {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            &BluetoothAdapter::Bluez(ref bluez_adapter) => try!(bluez_adapter.get_device_list()),
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            &BluetoothAdapter::Android(ref android_adapter) => try!(android_adapter.get_device_list()),
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            &BluetoothAdapter::Empty(ref adapter) => try!(adapter.get_device_list()),
+            #[cfg(feature = "bluetooth")]
+            &BluetoothAdapter::Mock(ref fake_adapter) => try!(fake_adapter.get_device_list()),
+        };
         Ok(device_list.into_iter().map(|device| BluetoothDevice::create_device(self.clone(), device)).collect())
     }
 
-    pub fn get_device(&self, address: String) -> Result<Option<BluetoothDevice>, Box<Error>> {
+    /*pub fn get_device(&self, address: String) -> Result<Option<BluetoothDevice>, Box<Error>> {
         let devices = try!(self.get_devices());
         for device in devices {
             if try!(device.get_address()) == address {
@@ -198,679 +195,1200 @@ impl BluetoothAdapter {
             }
         }
         Ok(None)
-    }
+    }*/
 
     pub fn get_address(&self) -> Result<String, Box<Error>> {
-        self.get_adapter().get_address()
+        match self {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            &BluetoothAdapter::Bluez(ref bluez_adapter) => bluez_adapter.get_address(),
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            &BluetoothAdapter::Android(ref android_adapter) => android_adapter.get_address(),
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            &BluetoothAdapter::Empty(ref adapter) => adapter.get_address(),
+            #[cfg(feature = "bluetooth")]
+            &BluetoothAdapter::Mock(ref fake_adapter) => fake_adapter.get_address(),
+        }
     }
 
-    #[cfg(feature = "bluetooth-test")]
+    #[cfg(feature = "bluetooth")]
     pub fn set_address(&self, address: String) -> Result<(), Box<Error>> {
-        self.get_adapter().set_address(address)
+        match self {
+            &BluetoothAdapter::Mock(ref fake_adapter) => fake_adapter.set_address(address),
+            _ => Err(Box::from(NOT_SUPPORTED_ERROR)),
+        }
     }
 
     pub fn get_name(&self) -> Result<String, Box<Error>> {
-        self.get_adapter().get_name()
+        match self {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            &BluetoothAdapter::Bluez(ref bluez_adapter) => bluez_adapter.get_name(),
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            &BluetoothAdapter::Android(ref android_adapter) => android_adapter.get_name(),
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            &BluetoothAdapter::Empty(ref adapter) => adapter.get_name(),
+            #[cfg(feature = "bluetooth")]
+            &BluetoothAdapter::Mock(ref fake_adapter) => fake_adapter.get_name(),
+        }
     }
 
-    #[cfg(feature = "bluetooth-test")]
+    #[cfg(feature = "bluetooth")]
     pub fn set_name(&self, name: String) -> Result<(), Box<Error>> {
-        self.get_adapter().set_name(name)
+        match self {
+            &BluetoothAdapter::Mock(ref fake_adapter) => fake_adapter.set_name(name),
+            _ => Err(Box::from(NOT_SUPPORTED_ERROR)),
+        }
     }
 
     pub fn get_alias(&self) -> Result<String, Box<Error>> {
-        self.get_adapter().get_alias()
+        match self {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            &BluetoothAdapter::Bluez(ref bluez_adapter) => bluez_adapter.get_alias(),
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            &BluetoothAdapter::Android(ref android_adapter) => android_adapter.get_alias(),
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            &BluetoothAdapter::Empty(ref adapter) => adapter.get_alias(),
+            #[cfg(feature = "bluetooth")]
+            &BluetoothAdapter::Mock(ref fake_adapter) => fake_adapter.get_alias(),
+        }
     }
 
+    #[cfg(feature = "bluetooth")]
     pub fn set_alias(&self, value: String) -> Result<(), Box<Error>> {
-        self.get_adapter().set_alias(value)
+        match self {
+            &BluetoothAdapter::Mock(ref fake_adapter) => fake_adapter.set_alias(value),
+            _ => Err(Box::from(NOT_SUPPORTED_ERROR)),
+        }
     }
 
     pub fn get_class(&self) -> Result<u32, Box<Error>> {
-        self.get_adapter().get_class()
+        match self {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            &BluetoothAdapter::Bluez(ref bluez_adapter) => bluez_adapter.get_class(),
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            &BluetoothAdapter::Android(ref android_adapter) => android_adapter.get_class(),
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            &BluetoothAdapter::Empty(ref adapter) => adapter.get_class(),
+            #[cfg(feature = "bluetooth")]
+            &BluetoothAdapter::Mock(ref fake_adapter) => fake_adapter.get_class(),
+        }
     }
 
-    #[cfg(feature = "bluetooth-test")]
+    #[cfg(feature = "bluetooth")]
     pub fn set_class(&self, class: u32) -> Result<(), Box<Error>> {
-        self.get_adapter().set_class(class)
+        match self {
+            &BluetoothAdapter::Mock(ref fake_adapter) => fake_adapter.set_class(class),
+            _ => Err(Box::from(NOT_SUPPORTED_ERROR)),
+        }
     }
 
     pub fn is_powered(&self) -> Result<bool, Box<Error>> {
-        self.get_adapter().is_powered()
+        match self {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            &BluetoothAdapter::Bluez(ref bluez_adapter) => bluez_adapter.is_powered(),
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            &BluetoothAdapter::Android(ref android_adapter) => android_adapter.is_powered(),
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            &BluetoothAdapter::Empty(ref adapter) => adapter.is_powered(),
+            #[cfg(feature = "bluetooth")]
+            &BluetoothAdapter::Mock(ref fake_adapter) => fake_adapter.is_powered(),
+        }
     }
 
+    #[cfg(feature = "bluetooth")]
     pub fn set_powered(&self, value: bool) -> Result<(), Box<Error>> {
-        self.get_adapter().set_powered(value)
+        match self {
+            &BluetoothAdapter::Mock(ref fake_adapter) => fake_adapter.set_powered(value),
+            _ => Err(Box::from(NOT_SUPPORTED_ERROR)),
+        }
     }
 
-    #[cfg(feature = "bluetooth-test")]
+    #[cfg(feature = "bluetooth")]
     pub fn is_present(&self) -> Result<bool, Box<Error>> {
-        self.get_adapter().is_present()
+        match self {
+            &BluetoothAdapter::Mock(ref fake_adapter) => fake_adapter.is_present(),
+            _ => Err(Box::from(NOT_SUPPORTED_ERROR)),
+        }
     }
 
-    #[cfg(feature = "bluetooth-test")]
+    #[cfg(feature = "bluetooth")]
     pub fn set_present(&self, value: bool) -> Result<(), Box<Error>> {
-        self.get_adapter().set_present(value)
+        match self {
+            &BluetoothAdapter::Mock(ref fake_adapter) => fake_adapter.set_present(value),
+            _ => Err(Box::from(NOT_SUPPORTED_ERROR)),
+        }
     }
 
     pub fn is_discoverable(&self) -> Result<bool, Box<Error>> {
-        self.get_adapter().is_discoverable()
+        match self {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            &BluetoothAdapter::Bluez(ref bluez_adapter) => bluez_adapter.is_discoverable(),
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            &BluetoothAdapter::Android(ref android_adapter) => android_adapter.is_discoverable(),
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            &BluetoothAdapter::Empty(ref adapter) => adapter.is_discoverable(),
+            #[cfg(feature = "bluetooth")]
+            &BluetoothAdapter::Mock(ref fake_adapter) => fake_adapter.is_discoverable(),
+        }
     }
 
+    #[cfg(feature = "bluetooth")]
     pub fn set_discoverable(&self, value: bool) -> Result<(), Box<Error>> {
-        self.get_adapter().set_discoverable(value)
+        match self {
+            &BluetoothAdapter::Mock(ref fake_adapter) => fake_adapter.set_discoverable(value),
+            _ => Err(Box::from(NOT_SUPPORTED_ERROR)),
+        }
     }
 
     pub fn is_pairable(&self) -> Result<bool, Box<Error>> {
-        self.get_adapter().is_pairable()
+        match self {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            &BluetoothAdapter::Bluez(ref bluez_adapter) => bluez_adapter.is_pairable(),
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            &BluetoothAdapter::Android(ref android_adapter) => android_adapter.is_pairable(),
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            &BluetoothAdapter::Empty(ref adapter) => adapter.is_pairable(),
+            #[cfg(feature = "bluetooth")]
+            &BluetoothAdapter::Mock(ref fake_adapter) => fake_adapter.is_pairable(),
+        }
     }
 
+    #[cfg(feature = "bluetooth")]
     pub fn set_pairable(&self, value: bool) -> Result<(), Box<Error>> {
-        self.get_adapter().set_pairable(value)
+        match self {
+            &BluetoothAdapter::Mock(ref fake_adapter) => fake_adapter.set_pairable(value),
+            _ => Err(Box::from(NOT_SUPPORTED_ERROR)),
+        }
     }
 
     pub fn get_pairable_timeout(&self) -> Result<u32, Box<Error>> {
-        self.get_adapter().get_pairable_timeout()
+        match self {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            &BluetoothAdapter::Bluez(ref bluez_adapter) => bluez_adapter.get_pairable_timeout(),
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            &BluetoothAdapter::Android(ref android_adapter) => android_adapter.get_pairable_timeout(),
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            &BluetoothAdapter::Empty(ref adapter) => adapter.get_pairable_timeout(),
+            #[cfg(feature = "bluetooth")]
+            &BluetoothAdapter::Mock(ref fake_adapter) => fake_adapter.get_pairable_timeout(),
+        }
     }
 
+    #[cfg(feature = "bluetooth")]
     pub fn set_pairable_timeout(&self, value: u32) -> Result<(), Box<Error>> {
-        self.get_adapter().set_pairable_timeout(value)
+        match self {
+            &BluetoothAdapter::Mock(ref fake_adapter) => fake_adapter.set_pairable_timeout(value),
+            _ => Err(Box::from(NOT_SUPPORTED_ERROR)),
+        }
     }
 
     pub fn get_discoverable_timeout(&self) -> Result<u32, Box<Error>> {
-        self.get_adapter().get_discoverable_timeout()
+        match self {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            &BluetoothAdapter::Bluez(ref bluez_adapter) => bluez_adapter.get_discoverable_timeout(),
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            &BluetoothAdapter::Android(ref android_adapter) => android_adapter.get_discoverable_timeout(),
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            &BluetoothAdapter::Empty(ref adapter) => adapter.get_discoverable_timeout(),
+            #[cfg(feature = "bluetooth")]
+            &BluetoothAdapter::Mock(ref fake_adapter) => fake_adapter.get_discoverable_timeout(),
+        }
     }
 
+    #[cfg(feature = "bluetooth")]
     pub fn set_discoverable_timeout(&self, value: u32) -> Result<(), Box<Error>> {
-        self.get_adapter().set_discoverable_timeout(value)
+        match self {
+            &BluetoothAdapter::Mock(ref fake_adapter) => fake_adapter.set_discoverable_timeout(value),
+            _ => Err(Box::from(NOT_SUPPORTED_ERROR)),
+        }
     }
 
     pub fn is_discovering(&self) -> Result<bool, Box<Error>> {
-        self.get_adapter().is_discovering()
+        match self {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            &BluetoothAdapter::Bluez(ref bluez_adapter) => bluez_adapter.is_discovering(),
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            &BluetoothAdapter::Android(ref android_adapter) => android_adapter.is_discovering(),
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            &BluetoothAdapter::Empty(ref adapter) => adapter.is_discovering(),
+            #[cfg(feature = "bluetooth")]
+            &BluetoothAdapter::Mock(ref fake_adapter) => fake_adapter.is_discovering(),
+        }
     }
 
-    #[cfg(feature = "bluetooth-test")]
+    #[cfg(feature = "bluetooth")]
     pub fn set_discovering(&self, is_discovering: bool) -> Result<(), Box<Error>> {
-        self.get_adapter().set_discovering(is_discovering)
+        match self {
+            &BluetoothAdapter::Mock(ref fake_adapter) => fake_adapter.set_discovering(is_discovering),
+            _ => Err(Box::from(NOT_SUPPORTED_ERROR)),
+        }
     }
 
-    #[cfg(feature = "bluetooth-test")]
+    #[cfg(feature = "bluetooth")]
     pub fn set_can_start_discovery(&self, can_start_discovery: bool) -> Result<(), Box<Error>> {
-        self.get_adapter().set_can_start_discovery(can_start_discovery)
+        match self {
+            &BluetoothAdapter::Mock(ref fake_adapter) => fake_adapter.set_can_start_discovery(can_start_discovery),
+            _ => Err(Box::from(NOT_SUPPORTED_ERROR)),
+        }
     }
 
+    #[cfg(feature = "bluetooth")]
     pub fn create_discovery_session(&self) -> Result<BluetoothDiscoverySession, Box<Error>> {
         BluetoothDiscoverySession::create_session(self.clone())
     }
 
     pub fn get_uuids(&self) -> Result<Vec<String>, Box<Error>> {
-        self.get_adapter().get_uuids()
+        match self {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            &BluetoothAdapter::Bluez(ref bluez_adapter) => bluez_adapter.get_uuids(),
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            &BluetoothAdapter::Android(ref android_adapter) => android_adapter.get_uuids(),
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            &BluetoothAdapter::Empty(ref adapter) => adapter.get_uuids(),
+            #[cfg(feature = "bluetooth")]
+            &BluetoothAdapter::Mock(ref fake_adapter) => fake_adapter.get_uuids(),
+        }
     }
 
-    #[cfg(feature = "bluetooth-test")]
+    #[cfg(feature = "bluetooth")]
     pub fn set_uuids(&self, uuids: Vec<String>) -> Result<(), Box<Error>> {
-        self.get_adapter().set_uuids(uuids)
+        match self {
+            &BluetoothAdapter::Mock(ref fake_adapter) => fake_adapter.set_uuids(uuids),
+            _ => Err(Box::from(NOT_SUPPORTED_ERROR)),
+        }
     }
 
     pub fn get_vendor_id_source(&self) -> Result<String, Box<Error>> {
-        self.get_adapter().get_vendor_id_source()
+        match self {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            &BluetoothAdapter::Bluez(ref bluez_adapter) => bluez_adapter.get_vendor_id_source(),
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            &BluetoothAdapter::Android(ref android_adapter) => android_adapter.get_vendor_id_source(),
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            &BluetoothAdapter::Empty(ref adapter) => adapter.get_vendor_id_source(),
+            #[cfg(feature = "bluetooth")]
+            &BluetoothAdapter::Mock(ref fake_adapter) => fake_adapter.get_vendor_id_source(),
+        }
     }
 
     pub fn get_vendor_id(&self) -> Result<u32, Box<Error>> {
-        self.get_adapter().get_vendor_id()
+        match self {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            &BluetoothAdapter::Bluez(ref bluez_adapter) => bluez_adapter.get_vendor_id(),
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            &BluetoothAdapter::Android(ref android_adapter) => android_adapter.get_vendor_id(),
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            &BluetoothAdapter::Empty(ref adapter) => adapter.get_vendor_id(),
+            #[cfg(feature = "bluetooth")]
+            &BluetoothAdapter::Mock(ref fake_adapter) => fake_adapter.get_vendor_id(),
+        }
     }
 
     pub fn get_product_id(&self) -> Result<u32, Box<Error>> {
-        self.get_adapter().get_product_id()
+        match self {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            &BluetoothAdapter::Bluez(ref bluez_adapter) => bluez_adapter.get_product_id(),
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            &BluetoothAdapter::Android(ref android_adapter) => android_adapter.get_product_id(),
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            &BluetoothAdapter::Empty(ref adapter) => adapter.get_product_id(),
+            #[cfg(feature = "bluetooth")]
+            &BluetoothAdapter::Mock(ref fake_adapter) => fake_adapter.get_product_id(),
+        }
     }
 
     pub fn get_device_id(&self) -> Result<u32, Box<Error>> {
-        self.get_adapter().get_device_id()
+        match self {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            &BluetoothAdapter::Bluez(ref bluez_adapter) => bluez_adapter.get_device_id(),
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            &BluetoothAdapter::Android(ref android_adapter) => android_adapter.get_device_id(),
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            &BluetoothAdapter::Empty(ref adapter) => adapter.get_device_id(),
+            #[cfg(feature = "bluetooth")]
+            &BluetoothAdapter::Mock(ref fake_adapter) => fake_adapter.get_device_id(),
+        }
     }
 
     pub fn get_modalias(&self) -> Result<(String, u32, u32, u32), Box<Error>> {
-        self.get_adapter().get_modalias()
+        match self {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            &BluetoothAdapter::Bluez(ref bluez_adapter) => bluez_adapter.get_modalias(),
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            &BluetoothAdapter::Android(ref android_adapter) => android_adapter.get_modalias(),
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            &BluetoothAdapter::Empty(ref adapter) => adapter.get_modalias(),
+            #[cfg(feature = "bluetooth")]
+            &BluetoothAdapter::Mock(ref fake_adapter) => fake_adapter.get_modalias(),
+        }
     }
 
-    #[cfg(feature = "bluetooth-test")]
+    #[cfg(feature = "bluetooth")]
     pub fn set_modalias(&self, modalias: String) -> Result<(), Box<Error>> {
-        self.get_adapter().set_modalias(modalias)
+        match self {
+            &BluetoothAdapter::Mock(ref fake_adapter) => fake_adapter.set_modalias(modalias),
+            _ => Err(Box::from(NOT_SUPPORTED_ERROR)),
+        }
     }
 }
 
 impl BluetoothDiscoverySession {
-    #[cfg(all(target_os = "linux", feature = "bluetooth"))]
     pub fn create_session(adapter: BluetoothAdapter) -> Result<BluetoothDiscoverySession, Box<Error>> {
-        let bluez_session = try!(BluetoothDiscoverySessionBluez::create_session(adapter.get_id()));
-        Ok(BluetoothDiscoverySession{
-            adapter: RefCell::new(adapter),
-            session: Arc::new(bluez_session),
-        })
-    }
-
-    #[cfg(all(target_os = "android", feature = "bluetooth"))]
-    pub fn create_session(adapter: BluetoothAdapter) -> Result<BluetoothDiscoverySession, Box<Error>> {
-        let blurdroid_session = try!(BluetoothDiscoverySessionAndroid::create_session(adapter.get_adapter()));
-        Ok(BluetoothDiscoverySession{
-            adapter: RefCell::new(adapter),
-            session: Arc::new(blurdroid_session),
-        })
-    }
-
-    #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"), feature = "bluetooth-test")))]
-    pub fn create_session(adapter: BluetoothAdapter) -> Result<BluetoothDiscoverySession, Box<Error>> {
-        let empty_session = try!(BluetoothDiscoverySessionEmpty::create_session(adapter.get_adapter()));
-        Ok(BluetoothDiscoverySession{
-            adapter: RefCell::new(adapter),
-            session: Arc::new(empty_session),
-        })
-    }
-
-    #[cfg(feature = "bluetooth-test")]
-    pub fn create_session(adapter: BluetoothAdapter) -> Result<BluetoothDiscoverySession, Box<Error>> {
-        let test_session = try!(FakeBluetoothDiscoverySession::create_session(adapter.get_adapter()));
-        Ok(BluetoothDiscoverySession{
-            adapter: RefCell::new(adapter),
-            session: Arc::new(test_session),
-        })
-    }
-
-    pub fn get_adapter(&self) -> BluetoothAdapter {
-        self.adapter.borrow_mut().clone()
+        match adapter {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            BluetoothAdapter::Bluez(bluez_adapter) => {
+                let bluez_session = try!(BluetoothDiscoverySessionBluez::create_session(bluez_adapter.get_id()));
+                Ok(BluetoothDiscoverySession::Bluez(Arc::new(bluez_session)))
+            },
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            BluetoothAdapter::Android(android_adapter) => {
+                let blurdroid_session = try!(BluetoothDiscoverySessionAndroid::create_session(android_adapter));
+                Ok(BluetoothDiscoverySession::Android(Arc::new(blurdroid_session)))
+            },
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            BluetoothAdapter::Empty(adapter) => {
+                let empty_session = try!(BluetoothDiscoverySessionEmpty::create_session(adapter.get_adapter()));
+                Ok(BluetoothDiscoverySession::Empty(Arc::new(empty_session)))
+            },
+            #[cfg(feature = "bluetooth")]
+            BluetoothAdapter::Mock(fake_adapter) => {
+                let test_session = try!(FakeBluetoothDiscoverySession::create_session(fake_adapter));
+                Ok(BluetoothDiscoverySession::Mock(Arc::new(test_session)))
+            },
+        }
     }
 
     pub fn start_discovery(&self) -> Result<(), Box<Error>> {
-        self.session.start_discovery()
+        match self {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            &BluetoothDiscoverySession::Bluez(ref bluez_session) => bluez_session.start_discovery(),
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            &BluetoothDiscoverySession::Android(ref android_session) => android_session.start_discovery(),
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            &BluetoothDiscoverySession::Empty(ref adapter) => adapter.start_discovery(),
+            #[cfg(feature = "bluetooth")]
+            &BluetoothDiscoverySession::Mock(ref fake_session) => fake_session.start_discovery(),
+        }
     }
 
     pub fn stop_discovery(&self) -> Result<(), Box<Error>> {
-        self.session.stop_discovery()
+        match self {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            &BluetoothDiscoverySession::Bluez(ref bluez_session) => bluez_session.stop_discovery(),
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            &BluetoothDiscoverySession::Android(ref android_session) => android_session.stop_discovery(),
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            &BluetoothDiscoverySession::Empty(ref adapter) => adapter.stop_discovery(),
+            #[cfg(feature = "bluetooth")]
+            &BluetoothDiscoverySession::Mock(ref fake_session) => fake_session.stop_discovery(),
+        }
     }
 }
 
 impl BluetoothDevice {
-    #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+
     pub fn create_device(adapter: BluetoothAdapter, device: String) -> BluetoothDevice {
-        BluetoothDevice{
-            adapter: RefCell::new(adapter),
-            device: Arc::new(BluetoothDeviceBluez::new(device.clone())),
+        match adapter {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            BluetoothAdapter::Bluez(_bluez_adapter) => {
+                BluetoothDevice::Bluez(Arc::new(BluetoothDeviceBluez::new(device)))
+            },
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            BluetoothAdapter::Android(android_adapter) => {
+                BluetoothDevice::Android(Arc::new(BluetoothDeviceAndroid::new(android_adapter, device)))
+            },
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            BluetoothAdapter::Empty(adapter) => {
+                BluetoothDevice::Empty(Arc::new(BluetoothDeviceEmpty::new(device)))
+            },
+            #[cfg(feature = "bluetooth")]
+            BluetoothAdapter::Mock(fake_adapter) => {
+                BluetoothDevice::Mock(FakeBluetoothDevice::new_empty(fake_adapter, device))
+            },
         }
-    }
-
-    #[cfg(all(target_os = "android", feature = "bluetooth"))]
-    pub fn create_device(adapter: BluetoothAdapter, device: String) -> BluetoothDevice {
-        BluetoothDevice{
-            adapter: RefCell::new(adapter.clone()),
-            device: Arc::new(BluetoothDeviceAndroid::new(adapter.get_adapter(), device.clone())),
-        }
-    }
-
-    #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"), feature = "bluetooth-test")))]
-    pub fn create_device(adapter: BluetoothAdapter, device: String) -> BluetoothDevice {
-        BluetoothDevice{
-            adapter: RefCell::new(adapter),
-            device: Arc::new(BluetoothDeviceEmpty::new(device.clone())),
-        }
-    }
-
-    #[cfg(feature = "bluetooth-test")]
-    pub fn create_device(adapter: BluetoothAdapter, device_id: String) -> BluetoothDevice {
-        BluetoothDevice {
-            adapter: RefCell::new(adapter.clone()),
-            device: FakeBluetoothDevice::new_empty(adapter.get_adapter(), device_id),
-        }
-    }
-
-    #[cfg(all(target_os = "linux", feature = "bluetooth"))]
-    fn get_device(&self) -> Arc<BluetoothDeviceBluez> {
-        self.device.clone()
-    }
-
-    #[cfg(all(target_os = "android", feature = "bluetooth"))]
-    fn get_device(&self) -> Arc<BluetoothDeviceAndroid> {
-        self.device.clone()
-    }
-
-    #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"), feature = "bluetooth-test")))]
-    fn get_device(&self) -> Arc<BluetoothDeviceEmpty> {
-        self.device.clone()
-    }
-
-    #[cfg(feature = "bluetooth-test")]
-    fn get_device(&self) -> Arc<FakeBluetoothDevice> {
-        self.device.clone()
     }
 
     pub fn get_id(&self) -> String {
-        self.get_device().get_id()
+        match self {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            &BluetoothDevice::Bluez(ref bluez_device) => bluez_device.get_id(),
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            &BluetoothDevice::Android(ref android_device) => android_device.get_id(),
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            &BluetoothDevice::Empty(ref device) => device.get_id(),
+            #[cfg(feature = "bluetooth")]
+            &BluetoothDevice::Mock(ref fake_device) => fake_device.get_id(),
+        }
     }
 
-    #[cfg(feature = "bluetooth-test")]
+    #[cfg(feature = "bluetooth")]
     pub fn set_id(&self, id: String) {
-        self.get_device().set_id(id)
-    }
-
-    pub fn get_adapter(&self) -> BluetoothAdapter {
-        self.adapter.borrow_mut().clone()
+        match self {
+            &BluetoothDevice::Mock(ref fake_device) => fake_device.set_id(id),
+            _ => (),
+        }
     }
 
     pub fn get_address(&self) -> Result<String, Box<Error>> {
-        self.get_device().get_address()
+        match self {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            &BluetoothDevice::Bluez(ref bluez_device) => bluez_device.get_address(),
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            &BluetoothDevice::Android(ref android_device) => android_device.get_address(),
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            &BluetoothDevice::Empty(ref device) => device.get_address(),
+            #[cfg(feature = "bluetooth")]
+            &BluetoothDevice::Mock(ref fake_device) => fake_device.get_address(),
+        }
     }
 
-    #[cfg(feature = "bluetooth-test")]
+    #[cfg(feature = "bluetooth")]
     pub fn set_address(&self, address: String) -> Result<(), Box<Error>> {
-        self.get_device().set_address(address)
+        match self {
+            &BluetoothDevice::Mock(ref fake_device) => fake_device.set_address(address),
+            _ => Err(Box::from(NOT_SUPPORTED_ERROR)),
+        }
     }
 
     pub fn get_name(&self) -> Result<String, Box<Error>> {
-        self.get_device().get_name()
+        match self {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            &BluetoothDevice::Bluez(ref bluez_device) => bluez_device.get_name(),
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            &BluetoothDevice::Android(ref android_device) => android_device.get_name(),
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            &BluetoothDevice::Empty(ref device) => device.get_name(),
+            #[cfg(feature = "bluetooth")]
+            &BluetoothDevice::Mock(ref fake_device) => fake_device.get_name(),
+        }
     }
 
-    #[cfg(feature = "bluetooth-test")]
-    pub fn set_name(&self, address: String) -> Result<(), Box<Error>> {
-        self.get_device().set_name(address)
+    #[cfg(feature = "bluetooth")]
+    pub fn set_name(&self, name: String) -> Result<(), Box<Error>> {
+        match self {
+            &BluetoothDevice::Mock(ref fake_device) => fake_device.set_name(name),
+            _ => Err(Box::from(NOT_SUPPORTED_ERROR)),
+        }
     }
 
     pub fn get_icon(&self) -> Result<String, Box<Error>> {
-        self.get_device().get_icon()
+        match self {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            &BluetoothDevice::Bluez(ref bluez_device) => bluez_device.get_icon(),
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            &BluetoothDevice::Android(ref android_device) => android_device.get_icon(),
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            &BluetoothDevice::Empty(ref device) => device.get_icon(),
+            #[cfg(feature = "bluetooth")]
+            &BluetoothDevice::Mock(ref fake_device) => fake_device.get_icon(),
+        }
     }
 
     pub fn get_class(&self) -> Result<u32, Box<Error>> {
-        self.get_device().get_class()
+        match self {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            &BluetoothDevice::Bluez(ref bluez_device) => bluez_device.get_class(),
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            &BluetoothDevice::Android(ref android_device) => android_device.get_class(),
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            &BluetoothDevice::Empty(ref device) => device.get_class(),
+            #[cfg(feature = "bluetooth")]
+            &BluetoothDevice::Mock(ref fake_device) => fake_device.get_class(),
+        }
     }
 
     pub fn get_appearance(&self) -> Result<u16, Box<Error>> {
-        self.get_device().get_appearance()
+        match self {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            &BluetoothDevice::Bluez(ref bluez_device) => bluez_device.get_appearance(),
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            &BluetoothDevice::Android(ref android_device) => android_device.get_appearance(),
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            &BluetoothDevice::Empty(ref device) => device.get_appearance(),
+            #[cfg(feature = "bluetooth")]
+            &BluetoothDevice::Mock(ref fake_device) => fake_device.get_appearance(),
+        }
     }
 
-    #[cfg(feature = "bluetooth-test")]
+    #[cfg(feature = "bluetooth")]
     pub fn set_appearance(&self, appearance: u16) -> Result<(), Box<Error>> {
-        self.get_device().set_appearance(appearance)
+        match self {
+            &BluetoothDevice::Mock(ref fake_device) => fake_device.set_appearance(appearance),
+            _ => Err(Box::from(NOT_SUPPORTED_ERROR)),
+        }
     }
 
     pub fn get_uuids(&self) -> Result<Vec<String>, Box<Error>> {
-        self.get_device().get_uuids()
+        match self {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            &BluetoothDevice::Bluez(ref bluez_device) => bluez_device.get_uuids(),
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            &BluetoothDevice::Android(ref android_device) => android_device.get_uuids(),
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            &BluetoothDevice::Empty(ref device) => device.get_uuids(),
+            #[cfg(feature = "bluetooth")]
+            &BluetoothDevice::Mock(ref fake_device) => fake_device.get_uuids(),
+        }
     }
 
-    #[cfg(feature = "bluetooth-test")]
+    #[cfg(feature = "bluetooth")]
     pub fn set_uuids(&self, uuids: Vec<String>) -> Result<(), Box<Error>> {
-        self.get_device().set_uuids(uuids)
+        match self {
+            &BluetoothDevice::Mock(ref fake_device) => fake_device.set_uuids(uuids),
+            _ => Err(Box::from(NOT_SUPPORTED_ERROR)),
+        }
     }
 
     pub fn is_paired(&self) -> Result<bool, Box<Error>> {
-        self.get_device().is_paired()
+        match self {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            &BluetoothDevice::Bluez(ref bluez_device) => bluez_device.is_paired(),
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            &BluetoothDevice::Android(ref android_device) => android_device.is_paired(),
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            &BluetoothDevice::Empty(ref device) => device.is_paired(),
+            #[cfg(feature = "bluetooth")]
+            &BluetoothDevice::Mock(ref fake_device) => fake_device.is_paired(),
+        }
     }
 
     pub fn is_connected(&self) -> Result<bool, Box<Error>> {
-        self.get_device().is_connected()
+        match self {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            &BluetoothDevice::Bluez(ref bluez_device) => bluez_device.is_connected(),
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            &BluetoothDevice::Android(ref android_device) => android_device.is_connected(),
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            &BluetoothDevice::Empty(ref device) => device.is_connected(),
+            #[cfg(feature = "bluetooth")]
+            &BluetoothDevice::Mock(ref fake_device) => fake_device.is_connected(),
+        }
     }
 
-    #[cfg(feature = "bluetooth-test")]
+    #[cfg(feature = "bluetooth")]
     pub fn is_connectable(&self) -> Result<bool, Box<Error>> {
-        self.get_device().is_connectable()
+        match self {
+            &BluetoothDevice::Mock(ref fake_device) => fake_device.is_connectable(),
+            _ => Err(Box::from(NOT_SUPPORTED_ERROR)),
+        }
     }
 
-    #[cfg(feature = "bluetooth-test")]
+    #[cfg(feature = "bluetooth")]
     pub fn set_connectable(&self, connectable: bool) -> Result<(), Box<Error>> {
-        self.get_device().set_connectable(connectable)
+        match self {
+            &BluetoothDevice::Mock(ref fake_device) => fake_device.set_connectable(connectable),
+            _ => Err(Box::from(NOT_SUPPORTED_ERROR)),
+        }
     }
 
     pub fn is_trusted(&self) -> Result<bool, Box<Error>> {
-        self.get_device().is_trusted()
+        match self {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            &BluetoothDevice::Bluez(ref bluez_device) => bluez_device.is_trusted(),
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            &BluetoothDevice::Android(ref android_device) => android_device.is_trusted(),
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            &BluetoothDevice::Empty(ref device) => device.is_trusted(),
+            #[cfg(feature = "bluetooth")]
+            &BluetoothDevice::Mock(ref fake_device) => fake_device.is_trusted(),
+        }
     }
 
     pub fn is_blocked(&self) -> Result<bool, Box<Error>> {
-        self.get_device().is_blocked()
+        match self {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            &BluetoothDevice::Bluez(ref bluez_device) => bluez_device.is_blocked(),
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            &BluetoothDevice::Android(ref android_device) => android_device.is_blocked(),
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            &BluetoothDevice::Empty(ref device) => device.is_blocked(),
+            #[cfg(feature = "bluetooth")]
+            &BluetoothDevice::Mock(ref fake_device) => fake_device.is_blocked(),
+        }
     }
 
     pub fn get_alias(&self) -> Result<String, Box<Error>> {
-        self.get_device().get_alias()
+        match self {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            &BluetoothDevice::Bluez(ref bluez_device) => bluez_device.get_alias(),
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            &BluetoothDevice::Android(ref android_device) => android_device.get_alias(),
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            &BluetoothDevice::Empty(ref device) => device.get_alias(),
+            #[cfg(feature = "bluetooth")]
+            &BluetoothDevice::Mock(ref fake_device) => fake_device.get_alias(),
+        }
     }
 
-    pub fn set_alias(&self, value: String) -> Result<(), Box<Error>> {
-        self.get_device().set_alias(value)
+    #[cfg(feature = "bluetooth")]
+    pub fn set_alias(&self, alias: String) -> Result<(), Box<Error>> {
+        match self {
+            &BluetoothDevice::Mock(ref fake_device) => fake_device.set_alias(alias),
+            _ => Err(Box::from(NOT_SUPPORTED_ERROR)),
+        }
     }
 
     pub fn is_legacy_pairing(&self) -> Result<bool, Box<Error>> {
-        self.get_device().is_legacy_pairing()
+        match self {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            &BluetoothDevice::Bluez(ref bluez_device) => bluez_device.is_legacy_pairing(),
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            &BluetoothDevice::Android(ref android_device) => android_device.is_legacy_pairing(),
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            &BluetoothDevice::Empty(ref device) => device.is_legacy_pairing(),
+            #[cfg(feature = "bluetooth")]
+            &BluetoothDevice::Mock(ref fake_device) => fake_device.is_legacy_pairing(),
+        }
     }
 
     pub fn get_vendor_id_source(&self) -> Result<String, Box<Error>> {
-        self.get_device().get_vendor_id_source()
+        match self {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            &BluetoothDevice::Bluez(ref bluez_device) => bluez_device.get_vendor_id_source(),
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            &BluetoothDevice::Android(ref android_device) => android_device.get_vendor_id_source(),
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            &BluetoothDevice::Empty(ref device) => device.get_vendor_id_source(),
+            #[cfg(feature = "bluetooth")]
+            &BluetoothDevice::Mock(ref fake_device) => fake_device.get_vendor_id_source(),
+        }
     }
 
     pub fn get_vendor_id(&self) -> Result<u32, Box<Error>> {
-        self.get_device().get_vendor_id()
+        match self {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            &BluetoothDevice::Bluez(ref bluez_device) => bluez_device.get_vendor_id(),
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            &BluetoothDevice::Android(ref android_device) => android_device.get_vendor_id(),
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            &BluetoothDevice::Empty(ref device) => device.get_vendor_id(),
+            #[cfg(feature = "bluetooth")]
+            &BluetoothDevice::Mock(ref fake_device) => fake_device.get_vendor_id(),
+        }
     }
 
     pub fn get_product_id(&self) -> Result<u32, Box<Error>> {
-        self.get_device().get_product_id()
+        match self {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            &BluetoothDevice::Bluez(ref bluez_device) => bluez_device.get_product_id(),
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            &BluetoothDevice::Android(ref android_device) => android_device.get_product_id(),
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            &BluetoothDevice::Empty(ref device) => device.get_product_id(),
+            #[cfg(feature = "bluetooth")]
+            &BluetoothDevice::Mock(ref fake_device) => fake_device.get_product_id(),
+        }
     }
 
     pub fn get_device_id(&self) -> Result<u32, Box<Error>> {
-        self.get_device().get_device_id()
+        match self {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            &BluetoothDevice::Bluez(ref bluez_device) => bluez_device.get_device_id(),
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            &BluetoothDevice::Android(ref android_device) => android_device.get_device_id(),
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            &BluetoothDevice::Empty(ref device) => device.get_device_id(),
+            #[cfg(feature = "bluetooth")]
+            &BluetoothDevice::Mock(ref fake_device) => fake_device.get_device_id(),
+        }
     }
 
     pub fn get_modalias(&self) -> Result<(String, u32, u32, u32), Box<Error>> {
-        self.get_device().get_modalias()
+        match self {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            &BluetoothDevice::Bluez(ref bluez_device) => bluez_device.get_modalias(),
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            &BluetoothDevice::Android(ref android_device) => android_device.get_modalias(),
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            &BluetoothDevice::Empty(ref device) => device.get_modalias(),
+            #[cfg(feature = "bluetooth")]
+            &BluetoothDevice::Mock(ref fake_device) => fake_device.get_modalias(),
+        }
     }
 
     pub fn get_rssi(&self) -> Result<i16, Box<Error>> {
-        self.get_device().get_rssi()
+        match self {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            &BluetoothDevice::Bluez(ref bluez_device) => bluez_device.get_rssi(),
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            &BluetoothDevice::Android(ref android_device) => android_device.get_rssi(),
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            &BluetoothDevice::Empty(ref device) => device.get_rssi(),
+            #[cfg(feature = "bluetooth")]
+            &BluetoothDevice::Mock(ref fake_device) => fake_device.get_rssi(),
+        }
     }
 
     pub fn get_tx_power(&self) -> Result<i16, Box<Error>> {
-        self.get_device().get_tx_power()
+        match self {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            &BluetoothDevice::Bluez(ref bluez_device) => bluez_device.get_tx_power(),
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            &BluetoothDevice::Android(ref android_device) => android_device.get_tx_power(),
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            &BluetoothDevice::Empty(ref device) => device.get_tx_power(),
+            #[cfg(feature = "bluetooth")]
+            &BluetoothDevice::Mock(ref fake_device) => fake_device.get_tx_power(),
+        }
     }
 
-    #[cfg(feature = "bluetooth-test")]
+    #[cfg(feature = "bluetooth")]
     pub fn set_tx_power(&self, tx_power: i16) -> Result<(), Box<Error>> {
-        self.get_device().set_tx_power(tx_power)
+        match self {
+            &BluetoothDevice::Mock(ref fake_device) => fake_device.set_tx_power(tx_power),
+            _ => Err(Box::from(NOT_SUPPORTED_ERROR)),
+        }
     }
 
     pub fn get_gatt_services(&self) -> Result<Vec<BluetoothGATTService>, Box<Error>> {
-        let services = try!(self.get_device().get_gatt_services());
+        let services = match self {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            &BluetoothDevice::Bluez(ref bluez_device) => try!(bluez_device.get_gatt_services()),
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            &BluetoothDevice::Android(ref android_device) => try!(android_device.get_gatt_services()),
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            &BluetoothDevice::Empty(ref adapter) => try!(adapter.get_gatt_services()),
+            #[cfg(feature = "bluetooth")]
+            &BluetoothDevice::Mock(ref fake_device) => try!(fake_device.get_gatt_services()),
+        };
         Ok(services.into_iter().map(|service| BluetoothGATTService::create_service(self.clone(), service)).collect())
     }
 
     pub fn connect(&self) -> Result<(), Box<Error>> {
-        self.get_device().connect()
+        match self {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            &BluetoothDevice::Bluez(ref bluez_device) => bluez_device.connect(),
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            &BluetoothDevice::Android(ref android_device) => android_device.connect(),
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            &BluetoothDevice::Empty(ref device) => device.connect(),
+            #[cfg(feature = "bluetooth")]
+            &BluetoothDevice::Mock(ref fake_device) => fake_device.connect(),
+        }
     }
 
     pub fn disconnect(&self) -> Result<(), Box<Error>> {
-        self.get_device().disconnect()
+        match self {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            &BluetoothDevice::Bluez(ref bluez_device) => bluez_device.disconnect(),
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            &BluetoothDevice::Android(ref android_device) => android_device.disconnect(),
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            &BluetoothDevice::Empty(ref device) => device.disconnect(),
+            #[cfg(feature = "bluetooth")]
+            &BluetoothDevice::Mock(ref fake_device) => fake_device.disconnect(),
+        }
     }
 
     pub fn connect_profile(&self, uuid: String) -> Result<(), Box<Error>> {
-        self.get_device().connect_profile(uuid)
+        match self {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            &BluetoothDevice::Bluez(ref bluez_device) => bluez_device.connect_profile(uuid),
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            &BluetoothDevice::Android(ref android_device) => android_device.connect_profile(uuid),
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            &BluetoothDevice::Empty(ref device) => device.connect_profile(uuid),
+            #[cfg(feature = "bluetooth")]
+            &BluetoothDevice::Mock(ref fake_device) => fake_device.connect_profile(uuid),
+        }
     }
 
     pub fn disconnect_profile(&self, uuid: String) -> Result<(), Box<Error>> {
-        self.get_device().disconnect_profile(uuid)
+        match self {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            &BluetoothDevice::Bluez(ref bluez_device) => bluez_device.disconnect_profile(uuid),
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            &BluetoothDevice::Android(ref android_device) => android_device.disconnect_profile(uuid),
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            &BluetoothDevice::Empty(ref device) => device.disconnect_profile(uuid),
+            #[cfg(feature = "bluetooth")]
+            &BluetoothDevice::Mock(ref fake_device) => fake_device.disconnect_profile(uuid),
+        }
     }
 
     pub fn pair(&self) -> Result<(), Box<Error>> {
-        self.get_device().pair()
+        match self {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            &BluetoothDevice::Bluez(ref bluez_device) => bluez_device.pair(),
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            &BluetoothDevice::Android(ref android_device) => android_device.pair(),
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            &BluetoothDevice::Empty(ref device) => device.pair(),
+            #[cfg(feature = "bluetooth")]
+            &BluetoothDevice::Mock(ref fake_device) => fake_device.pair(),
+        }
     }
 
     pub fn cancel_pairing(&self) -> Result<(), Box<Error>> {
-        self.get_device().cancel_pairing()
+        match self {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            &BluetoothDevice::Bluez(ref bluez_device) => bluez_device.cancel_pairing(),
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            &BluetoothDevice::Android(ref android_device) => android_device.cancel_pairing(),
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            &BluetoothDevice::Empty(ref device) => device.cancel_pairing(),
+            #[cfg(feature = "bluetooth")]
+            &BluetoothDevice::Mock(ref fake_device) => fake_device.cancel_pairing(),
+        }
     }
 }
 
 impl BluetoothGATTService {
-    #[cfg(all(target_os = "linux", feature = "bluetooth"))]
     pub fn create_service(device: BluetoothDevice, service: String) -> BluetoothGATTService {
-        BluetoothGATTService{
-            device: RefCell::new(device),
-            gatt_service: Arc::new(BluetoothGATTServiceBluez::new(service.clone())),
+        match device {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            BluetoothDevice::Bluez(_bluez_device) => {
+                BluetoothGATTService::Bluez(Arc::new(BluetoothGATTServiceBluez::new(service)))
+            },
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            BluetoothDevice::Android(android_device) => {
+                BluetoothGATTService::Android(Arc::new(BluetoothGATTServiceAndroid::new(android_device, service)))
+            },
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            BluetoothDevice::Empty(device) => {
+                BluetoothGATTService::Empty(Arc::new(BluetoothGATTServiceEmpty::new(service)))
+            },
+            #[cfg(feature = "bluetooth")]
+            BluetoothDevice::Mock(fake_device) => {
+                BluetoothGATTService::Mock(FakeBluetoothGATTService::new_empty(fake_device, service))
+            },
         }
-    }
-
-    #[cfg(all(target_os = "android", feature = "bluetooth"))]
-    pub fn create_service(device: BluetoothDevice, service: String) -> BluetoothGATTService {
-        BluetoothGATTService{
-            device: RefCell::new(device.clone()),
-            gatt_service: Arc::new(BluetoothGATTServiceAndroid::new(device.get_device(), service.clone())),
-        }
-    }
-
-    #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"), feature = "bluetooth-test")))]
-    pub fn create_service(device: BluetoothDevice, service: String) -> BluetoothGATTService {
-        BluetoothGATTService{
-            device: RefCell::new(device),
-            gatt_service: Arc::new(BluetoothGATTServiceEmpty::new(service.clone())),
-        }
-    }
-
-    #[cfg(feature = "bluetooth-test")]
-    pub fn create_service(device: BluetoothDevice, service: String) -> BluetoothGATTService {
-        BluetoothGATTService{
-            gatt_service: FakeBluetoothGATTService::new_empty(device.get_device(), service),
-            device: RefCell::new(device),
-        }
-    }
-
-    #[cfg(all(target_os = "linux", feature = "bluetooth"))]
-    fn get_gatt_service(&self) -> Arc<BluetoothGATTServiceBluez> {
-        self.gatt_service.clone()
-    }
-
-    #[cfg(all(target_os = "android", feature = "bluetooth"))]
-    fn get_gatt_service(&self) -> Arc<BluetoothGATTServiceAndroid> {
-        self.gatt_service.clone()
-    }
-
-    #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"), feature = "bluetooth-test")))]
-    fn get_gatt_service(&self) -> Arc<BluetoothGATTServiceEmpty> {
-        self.gatt_service.clone()
-    }
-
-    #[cfg(feature = "bluetooth-test")]
-    fn get_gatt_service(&self) -> Arc<FakeBluetoothGATTService> {
-        self.gatt_service.clone()
     }
 
     pub fn get_id(&self) -> String {
-        self.get_gatt_service().get_id()
-    }
-
-    pub fn get_device(&self) -> BluetoothDevice {
-        self.device.borrow_mut().clone()
+        match self {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            &BluetoothGATTService::Bluez(ref bluez_service) => bluez_service.get_id(),
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            &BluetoothGATTService::Android(ref android_service) => android_service.get_id(),
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            &BluetoothGATTService::Empty(ref service) => service.get_id(),
+            #[cfg(feature = "bluetooth")]
+            &BluetoothGATTService::Mock(ref fake_service) => fake_service.get_id(),
+        }
     }
 
     pub fn get_uuid(&self) -> Result<String, Box<Error>> {
-        self.get_gatt_service().get_uuid()
+        match self {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            &BluetoothGATTService::Bluez(ref bluez_service) => bluez_service.get_uuid(),
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            &BluetoothGATTService::Android(ref android_service) => android_service.get_uuid(),
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            &BluetoothGATTService::Empty(ref service) => service.get_uuid(),
+            #[cfg(feature = "bluetooth")]
+            &BluetoothGATTService::Mock(ref fake_service) => fake_service.get_uuid(),
+        }
     }
 
-    #[cfg(feature = "bluetooth-test")]
+    #[cfg(feature = "bluetooth")]
     pub fn set_uuid(&self, uuid: String) -> Result<(), Box<Error>> {
-        self.get_gatt_service().set_uuid(uuid)
+        match self {
+            &BluetoothGATTService::Mock(ref fake_service) => fake_service.set_uuid(uuid),
+            _ => Err(Box::from(NOT_SUPPORTED_ERROR)),
+        }
     }
 
     pub fn is_primary(&self) -> Result<bool, Box<Error>> {
-        self.get_gatt_service().is_primary()
+        match self {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            &BluetoothGATTService::Bluez(ref bluez_service) => bluez_service.is_primary(),
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            &BluetoothGATTService::Android(ref android_service) => android_service.is_primary(),
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            &BluetoothGATTService::Empty(ref service) => service.is_primary(),
+            #[cfg(feature = "bluetooth")]
+            &BluetoothGATTService::Mock(ref fake_service) => fake_service.is_primary(),
+        }
     }
 
-    #[cfg(feature = "bluetooth-test")]
+    #[cfg(feature = "bluetooth")]
     pub fn set_primary(&self, value: bool) -> Result<(), Box<Error>> {
-        self.get_gatt_service().set_is_primary(value)
+        match self {
+            &BluetoothGATTService::Mock(ref fake_service) => fake_service.set_is_primary(value),
+            _ => Err(Box::from(NOT_SUPPORTED_ERROR)),
+        }
     }
 
     pub fn get_includes(&self) -> Result<Vec<BluetoothGATTService>, Box<Error>> {
-        let services = try!(self.get_gatt_service().get_includes());
-        Ok(services.into_iter().map(|service| BluetoothGATTService::create_service(self.get_device(), service)).collect())
+        /*let services = try!(self.get_gatt_service().get_includes());
+        Ok(services.into_iter().map(|service| BluetoothGATTService::create_service(self.get_device(), service)).collect())*/
+        Err(Box::from(NOT_SUPPORTED_ERROR))
     }
 
     pub fn get_gatt_characteristics(&self) -> Result<Vec<BluetoothGATTCharacteristic>, Box<Error>> {
-        let characteristics = try!(self.get_gatt_service().get_gatt_characteristics());
+        let characteristics = match self {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            &BluetoothGATTService::Bluez(ref bluez_service) => try!(bluez_service.get_gatt_characteristics()),
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            &BluetoothGATTService::Android(ref android_service) => try!(android_service.get_gatt_characteristics()),
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            &BluetoothGATTService::Empty(ref service) => try!(service.get_gatt_characteristics()),
+            #[cfg(feature = "bluetooth")]
+            &BluetoothGATTService::Mock(ref fake_service) => try!(fake_service.get_gatt_characteristics()),
+        };
         Ok(characteristics.into_iter().map(|characteristic| BluetoothGATTCharacteristic::create_characteristic(self.clone(), characteristic)).collect())
     }
 }
 
 impl BluetoothGATTCharacteristic {
-    #[cfg(all(target_os = "linux", feature = "bluetooth"))]
     pub fn create_characteristic(service: BluetoothGATTService, characteristic: String) -> BluetoothGATTCharacteristic {
-        BluetoothGATTCharacteristic{
-            service: RefCell::new(service),
-            gatt_characteristic: Arc::new(BluetoothGATTCharacteristicBluez::new(characteristic.clone()))
+        match service {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            BluetoothGATTService::Bluez(_bluez_service) => {
+                BluetoothGATTCharacteristic::Bluez(Arc::new(BluetoothGATTCharacteristicBluez::new(characteristic)))
+            },
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            BluetoothGATTService::Android(android_service) => {
+                BluetoothGATTCharacteristic::Android(Arc::new(BluetoothGATTCharacteristicAndroid::new(android_service, characteristic)))
+            },
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            BluetoothGATTService::Empty(service) => {
+                BluetoothGATTCharacteristic::Empty(Arc::new(BluetoothGATTCharacteristicEmpty::new(characteristic)))
+            },
+            #[cfg(feature = "bluetooth")]
+            BluetoothGATTService::Mock(fake_service) => {
+                BluetoothGATTCharacteristic::Mock(FakeBluetoothGATTCharacteristic::new_empty(fake_service, characteristic))
+            },
         }
-    }
-
-    #[cfg(all(target_os = "android", feature = "bluetooth"))]
-    pub fn create_characteristic(service: BluetoothGATTService, characteristic: String) -> BluetoothGATTCharacteristic {
-        BluetoothGATTCharacteristic{
-            service: RefCell::new(service.clone()),
-            gatt_characteristic: Arc::new(BluetoothGATTCharacteristicAndroid::new(service.get_gatt_service(), characteristic.clone()))
-        }
-    }
-
-    #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"), feature = "bluetooth-test")))]
-    pub fn create_characteristic(service: BluetoothGATTService, characteristic: String) -> BluetoothGATTCharacteristic {
-        BluetoothGATTCharacteristic{
-            service: RefCell::new(service),
-            gatt_characteristic: Arc::new(BluetoothGATTCharacteristicEmpty::new(characteristic.clone()))
-        }
-    }
-
-    #[cfg(feature = "bluetooth-test")]
-    pub fn create_characteristic(service: BluetoothGATTService, characteristic: String) -> BluetoothGATTCharacteristic {
-        BluetoothGATTCharacteristic{
-            gatt_characteristic: FakeBluetoothGATTCharacteristic::new_empty(service.get_gatt_service(), characteristic),
-            service: RefCell::new(service),
-        }
-    }
-
-    #[cfg(all(target_os = "linux", feature = "bluetooth"))]
-    fn get_gatt_characteristic(&self) -> Arc<BluetoothGATTCharacteristicBluez> {
-        self.gatt_characteristic.clone()
-    }
-
-    #[cfg(all(target_os = "android", feature = "bluetooth"))]
-    fn get_gatt_characteristic(&self) -> Arc<BluetoothGATTCharacteristicAndroid> {
-        self.gatt_characteristic.clone()
-    }
-
-    #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"), feature = "bluetooth-test")))]
-    fn get_gatt_characteristic(&self) -> Arc<BluetoothGATTCharacteristicEmpty> {
-        self.gatt_characteristic.clone()
-    }
-
-    #[cfg(feature = "bluetooth-test")]
-    fn get_gatt_characteristic(&self) -> Arc<FakeBluetoothGATTCharacteristic> {
-        self.gatt_characteristic.clone()
     }
 
     pub fn get_id(&self) -> String {
-        self.get_gatt_characteristic().get_id()
-    }
-
-    pub fn get_service(&self) -> BluetoothGATTService {
-        self.service.borrow_mut().clone()
+        match self {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            &BluetoothGATTCharacteristic::Bluez(ref bluez_characteristic) => bluez_characteristic.get_id(),
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            &BluetoothGATTCharacteristic::Android(ref android_characteristic) => android_characteristic.get_id(),
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            &BluetoothGATTCharacteristic::Empty(ref characteristic) => characteristic.get_id(),
+            #[cfg(feature = "bluetooth")]
+            &BluetoothGATTCharacteristic::Mock(ref fake_characteristic) => fake_characteristic.get_id(),
+        }
     }
 
     pub fn get_uuid(&self) -> Result<String, Box<Error>> {
-        self.get_gatt_characteristic().get_uuid()
+        match self {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            &BluetoothGATTCharacteristic::Bluez(ref bluez_characteristic) => bluez_characteristic.get_uuid(),
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            &BluetoothGATTCharacteristic::Android(ref android_characteristic) => android_characteristic.get_uuid(),
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            &BluetoothGATTCharacteristic::Empty(ref characteristic) => characteristic.get_uuid(),
+            #[cfg(feature = "bluetooth")]
+            &BluetoothGATTCharacteristic::Mock(ref fake_characteristic) => fake_characteristic.get_uuid(),
+        }
     }
 
-    #[cfg(feature = "bluetooth-test")]
+    #[cfg(feature = "bluetooth")]
     pub fn set_uuid(&self, uuid: String) -> Result<(), Box<Error>> {
-        self.get_gatt_characteristic().set_uuid(uuid)
+        match self {
+            &BluetoothGATTCharacteristic::Mock(ref fake_characteristic) => fake_characteristic.set_uuid(uuid),
+            _ => Err(Box::from(NOT_SUPPORTED_ERROR)),
+        }
     }
 
     pub fn get_value(&self) -> Result<Vec<u8>, Box<Error>> {
-        self.get_gatt_characteristic().get_value()
+        match self {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            &BluetoothGATTCharacteristic::Bluez(ref bluez_characteristic) => bluez_characteristic.get_value(),
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            &BluetoothGATTCharacteristic::Android(ref android_characteristic) => android_characteristic.get_value(),
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            &BluetoothGATTCharacteristic::Empty(ref characteristic) => characteristic.get_value(),
+            #[cfg(feature = "bluetooth")]
+            &BluetoothGATTCharacteristic::Mock(ref fake_characteristic) => fake_characteristic.get_value(),
+        }
     }
 
     pub fn is_notifying(&self) -> Result<bool, Box<Error>> {
-        self.get_gatt_characteristic().is_notifying()
+        match self {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            &BluetoothGATTCharacteristic::Bluez(ref bluez_characteristic) => bluez_characteristic.is_notifying(),
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            &BluetoothGATTCharacteristic::Android(ref android_characteristic) => android_characteristic.is_notifying(),
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            &BluetoothGATTCharacteristic::Empty(ref characteristic) => characteristic.is_notifying(),
+            #[cfg(feature = "bluetooth")]
+            &BluetoothGATTCharacteristic::Mock(ref fake_characteristic) => fake_characteristic.is_notifying(),
+        }
     }
 
     pub fn get_flags(&self) -> Result<Vec<String>, Box<Error>> {
-        self.get_gatt_characteristic().get_flags()
+        match self {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            &BluetoothGATTCharacteristic::Bluez(ref bluez_characteristic) => bluez_characteristic.get_flags(),
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            &BluetoothGATTCharacteristic::Android(ref android_characteristic) => android_characteristic.get_flags(),
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            &BluetoothGATTCharacteristic::Empty(ref characteristic) => characteristic.get_flags(),
+            #[cfg(feature = "bluetooth")]
+            &BluetoothGATTCharacteristic::Mock(ref fake_characteristic) => fake_characteristic.get_flags(),
+        }
     }
 
     pub fn get_gatt_descriptors(&self) -> Result<Vec<BluetoothGATTDescriptor>, Box<Error>> {
-        let descriptors =  try!(self.get_gatt_characteristic().get_gatt_descriptors());
+        let descriptors =  match self {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            &BluetoothGATTCharacteristic::Bluez(ref bluez_characteristic) => try!(bluez_characteristic.get_gatt_descriptors()),
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            &BluetoothGATTCharacteristic::Android(ref android_characteristic) => try!(android_characteristic.get_gatt_descriptors()),
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            &BluetoothGATTCharacteristic::Empty(ref characteristic) => try!(characteristic.get_gatt_descriptors()),
+            #[cfg(feature = "bluetooth")]
+            &BluetoothGATTCharacteristic::Mock(ref fake_characteristic) => try!(fake_characteristic.get_gatt_descriptors()),
+        };
         Ok(descriptors.into_iter().map(|descriptor| BluetoothGATTDescriptor::create_descriptor(self.clone(), descriptor)).collect())
     }
 
     pub fn read_value(&self) -> Result<Vec<u8>, Box<Error>> {
-        self.get_gatt_characteristic().read_value()
+        match self {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            &BluetoothGATTCharacteristic::Bluez(ref bluez_characteristic) => bluez_characteristic.read_value(),
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            &BluetoothGATTCharacteristic::Android(ref android_characteristic) => android_characteristic.read_value(),
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            &BluetoothGATTCharacteristic::Empty(ref characteristic) => characteristic.read_value(),
+            #[cfg(feature = "bluetooth")]
+            &BluetoothGATTCharacteristic::Mock(ref fake_characteristic) => fake_characteristic.read_value(),
+        }
     }
 
     pub fn write_value(&self, values: Vec<u8>) -> Result<(), Box<Error>> {
-        self.get_gatt_characteristic().write_value(values)
+        match self {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            &BluetoothGATTCharacteristic::Bluez(ref bluez_characteristic) => bluez_characteristic.write_value(values),
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            &BluetoothGATTCharacteristic::Android(ref android_characteristic) => android_characteristic.write_value(values),
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            &BluetoothGATTCharacteristic::Empty(ref characteristic) => characteristic.write_value(values),
+            #[cfg(feature = "bluetooth")]
+            &BluetoothGATTCharacteristic::Mock(ref fake_characteristic) => fake_characteristic.write_value(values),
+        }
     }
 
     pub fn start_notify(&self) -> Result<(), Box<Error>> {
-        self.get_gatt_characteristic().start_notify()
+        match self {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            &BluetoothGATTCharacteristic::Bluez(ref bluez_characteristic) => bluez_characteristic.start_notify(),
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            &BluetoothGATTCharacteristic::Android(ref android_characteristic) => android_characteristic.start_notify(),
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            &BluetoothGATTCharacteristic::Empty(ref characteristic) => characteristic.start_notify(),
+            #[cfg(feature = "bluetooth")]
+            &BluetoothGATTCharacteristic::Mock(ref fake_characteristic) => fake_characteristic.start_notify(),
+        }
     }
 
     pub fn stop_notify(&self) -> Result<(), Box<Error>> {
-        self.get_gatt_characteristic().stop_notify()
+        match self {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            &BluetoothGATTCharacteristic::Bluez(ref bluez_characteristic) => bluez_characteristic.stop_notify(),
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            &BluetoothGATTCharacteristic::Android(ref android_characteristic) => android_characteristic.stop_notify(),
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            &BluetoothGATTCharacteristic::Empty(ref characteristic) => characteristic.stop_notify(),
+            #[cfg(feature = "bluetooth")]
+            &BluetoothGATTCharacteristic::Mock(ref fake_characteristic) => fake_characteristic.stop_notify(),
+        }
     }
 }
 
 impl BluetoothGATTDescriptor {
-    #[cfg(all(target_os = "linux", feature = "bluetooth"))]
     pub fn create_descriptor(characteristic: BluetoothGATTCharacteristic, descriptor: String) -> BluetoothGATTDescriptor {
-        BluetoothGATTDescriptor{
-            characteristic: RefCell::new(characteristic),
-            gatt_descriptor: Arc::new(BluetoothGATTDescriptorBluez::new(descriptor.clone()))
+        match characteristic {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            BluetoothGATTCharacteristic::Bluez(_bluez_characteristic) => {
+                BluetoothGATTDescriptor::Bluez(Arc::new(BluetoothGATTDescriptorBluez::new(descriptor)))
+            },
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            BluetoothGATTCharacteristic::Android(android_characteristic) => {
+                BluetoothGATTDescriptor::Android(Arc::new(BluetoothGATTDescriptorAndroid::new(android_characteristic, descriptor)))
+            },
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            BluetoothGATTCharacteristic::Empty(characteristic) => {
+                BluetoothGATTDescriptor::Empty(Arc::new(BluetoothGATTDescriptorEmpty::new(descriptor)))
+            },
+            #[cfg(feature = "bluetooth")]
+            BluetoothGATTCharacteristic::Mock(fake_characteristic) => {
+                BluetoothGATTDescriptor::Mock(FakeBluetoothGATTDescriptor::new_empty(fake_characteristic, descriptor))
+            },
         }
-    }
-
-    #[cfg(all(target_os = "android", feature = "bluetooth"))]
-    pub fn create_descriptor(characteristic: BluetoothGATTCharacteristic, descriptor: String) -> BluetoothGATTDescriptor {
-        BluetoothGATTDescriptor{
-            characteristic: RefCell::new(characteristic.clone()),
-            gatt_descriptor: Arc::new(BluetoothGATTDescriptorAndroid::new(characteristic.get_gatt_characteristic(), descriptor.clone()))
-        }
-    }
-
-    #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"), feature = "bluetooth-test")))]
-    pub fn create_descriptor(characteristic: BluetoothGATTCharacteristic, descriptor: String) -> BluetoothGATTDescriptor {
-        BluetoothGATTDescriptor{
-            characteristic: RefCell::new(characteristic),
-            gatt_descriptor: Arc::new(BluetoothGATTDescriptorEmpty::new(descriptor.clone()))
-        }
-    }
-
-    #[cfg(feature = "bluetooth-test")]
-    pub fn create_descriptor(characteristic: BluetoothGATTCharacteristic, descriptor: String) -> BluetoothGATTDescriptor {
-        BluetoothGATTDescriptor{
-            gatt_descriptor: FakeBluetoothGATTDescriptor::new_empty(characteristic.get_gatt_characteristic(), descriptor),
-            characteristic: RefCell::new(characteristic),
-        }
-    }
-
-    #[cfg(all(target_os = "linux", feature = "bluetooth"))]
-    fn get_gatt_descriptor(&self) -> Arc<BluetoothGATTDescriptorBluez> {
-        self.gatt_descriptor.clone()
-    }
-
-    #[cfg(all(target_os = "android", feature = "bluetooth"))]
-    fn get_gatt_descriptor(&self) -> Arc<BluetoothGATTDescriptorAndroid> {
-        self.gatt_descriptor.clone()
-    }
-
-    #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"), feature = "bluetooth-test")))]
-    fn get_gatt_descriptor(&self) -> Arc<BluetoothGATTDescriptorEmpty> {
-        self.gatt_descriptor.clone()
-    }
-
-    #[cfg(feature = "bluetooth-test")]
-    fn get_gatt_descriptor(&self) -> Arc<FakeBluetoothGATTDescriptor> {
-        self.gatt_descriptor.clone()
     }
 
     pub fn get_id(&self) -> String {
-        self.get_gatt_descriptor().get_id()
-    }
-
-    pub fn get_characteristic(&self) -> BluetoothGATTCharacteristic {
-        self.characteristic.borrow_mut().clone()
+        match self {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            &BluetoothGATTDescriptor::Bluez(ref bluez_descriptor) => bluez_descriptor.get_id(),
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            &BluetoothGATTDescriptor::Android(ref android_descriptor) => android_descriptor.get_id(),
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            &BluetoothGATTDescriptor::Empty(ref descriptor) => descriptor.get_id(),
+            #[cfg(feature = "bluetooth")]
+            &BluetoothGATTDescriptor::Mock(ref fake_descriptor) => fake_descriptor.get_id(),
+        }
     }
 
     pub fn get_uuid(&self) -> Result<String, Box<Error>> {
-        self.get_gatt_descriptor().get_uuid()
+        match self {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            &BluetoothGATTDescriptor::Bluez(ref bluez_descriptor) => bluez_descriptor.get_uuid(),
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            &BluetoothGATTDescriptor::Android(ref android_descriptor) => android_descriptor.get_uuid(),
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            &BluetoothGATTDescriptor::Empty(ref descriptor) => descriptor.get_uuid(),
+            #[cfg(feature = "bluetooth")]
+            &BluetoothGATTDescriptor::Mock(ref fake_descriptor) => fake_descriptor.get_uuid(),
+        }
     }
 
     pub fn get_value(&self) -> Result<Vec<u8>, Box<Error>> {
-        self.get_gatt_descriptor().get_value()
+        match self {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            &BluetoothGATTDescriptor::Bluez(ref bluez_descriptor) => bluez_descriptor.get_value(),
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            &BluetoothGATTDescriptor::Android(ref android_descriptor) => android_descriptor.get_value(),
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            &BluetoothGATTDescriptor::Empty(ref descriptor) => descriptor.get_value(),
+            #[cfg(feature = "bluetooth")]
+            &BluetoothGATTDescriptor::Mock(ref fake_descriptor) => fake_descriptor.get_value(),
+        }
     }
 
     pub fn get_flags(&self) -> Result<Vec<String>, Box<Error>> {
-        self.get_gatt_descriptor().get_flags()
+        match self {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            &BluetoothGATTDescriptor::Bluez(ref bluez_descriptor) => bluez_descriptor.get_flags(),
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            &BluetoothGATTDescriptor::Android(ref android_descriptor) => android_descriptor.get_flags(),
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            &BluetoothGATTDescriptor::Empty(ref descriptor) => descriptor.get_flags(),
+            #[cfg(feature = "bluetooth")]
+            &BluetoothGATTDescriptor::Mock(ref fake_descriptor) => fake_descriptor.get_flags(),
+        }
     }
 
     pub fn read_value(&self) -> Result<Vec<u8>, Box<Error>> {
-        self.get_gatt_descriptor().read_value()
+        match self {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            &BluetoothGATTDescriptor::Bluez(ref bluez_descriptor) => bluez_descriptor.read_value(),
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            &BluetoothGATTDescriptor::Android(ref android_descriptor) => android_descriptor.read_value(),
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            &BluetoothGATTDescriptor::Empty(ref descriptor) => descriptor.read_value(),
+            #[cfg(feature = "bluetooth")]
+            &BluetoothGATTDescriptor::Mock(ref fake_descriptor) => fake_descriptor.read_value(),
+        }
     }
 
     pub fn write_value(&self, values: Vec<u8>) -> Result<(), Box<Error>> {
-        self.get_gatt_descriptor().write_value(values)
+        match self {
+            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            &BluetoothGATTDescriptor::Bluez(ref bluez_descriptor) => bluez_descriptor.write_value(values),
+            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            &BluetoothGATTDescriptor::Android(ref android_descriptor) => android_descriptor.write_value(values),
+            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
+            &BluetoothGATTDescriptor::Empty(ref descriptor) => descriptor.write_value(values),
+            #[cfg(feature = "bluetooth")]
+            &BluetoothGATTDescriptor::Mock(ref fake_descriptor) => fake_descriptor.write_value(values),
+        }
     }
 }

--- a/src/bluetooth.rs
+++ b/src/bluetooth.rs
@@ -8,7 +8,7 @@ use blurz::bluetooth_adapter::BluetoothAdapter as BluetoothAdapterBluez;
 use blurdroid::bluetooth_adapter::Adapter as BluetoothAdapterAndroid;
 #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
 use empty::BluetoothAdapter as BluetoothAdapterEmpty;
-#[cfg(feature = "bluetooth")]
+#[cfg(feature = "bluetooth-test")]
 use blurmock::fake_adapter::FakeBluetoothAdapter;
 #[cfg(all(target_os = "linux", feature = "bluetooth"))]
 use blurz::bluetooth_device::BluetoothDevice as BluetoothDeviceBluez;
@@ -16,7 +16,7 @@ use blurz::bluetooth_device::BluetoothDevice as BluetoothDeviceBluez;
 use blurdroid::bluetooth_device::Device as BluetoothDeviceAndroid;
 #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
 use empty::BluetoothDevice as BluetoothDeviceEmpty;
-#[cfg(feature = "bluetooth")]
+#[cfg(feature = "bluetooth-test")]
 use blurmock::fake_device::FakeBluetoothDevice;
 #[cfg(all(target_os = "linux", feature = "bluetooth"))]
 use blurz::bluetooth_gatt_characteristic::BluetoothGATTCharacteristic as BluetoothGATTCharacteristicBluez;
@@ -24,7 +24,7 @@ use blurz::bluetooth_gatt_characteristic::BluetoothGATTCharacteristic as Bluetoo
 use blurdroid::bluetooth_gatt_characteristic::Characteristic as BluetoothGATTCharacteristicAndroid;
 #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
 use empty::BluetoothGATTCharacteristic as BluetoothGATTCharacteristicEmpty;
-#[cfg(feature = "bluetooth")]
+#[cfg(feature = "bluetooth-test")]
 use blurmock::fake_characteristic::FakeBluetoothGATTCharacteristic;
 #[cfg(all(target_os = "linux", feature = "bluetooth"))]
 use blurz::bluetooth_gatt_descriptor::BluetoothGATTDescriptor as BluetoothGATTDescriptorBluez;
@@ -32,7 +32,7 @@ use blurz::bluetooth_gatt_descriptor::BluetoothGATTDescriptor as BluetoothGATTDe
 use blurdroid::bluetooth_gatt_descriptor::Descriptor as BluetoothGATTDescriptorAndroid;
 #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
 use empty::BluetoothGATTDescriptor as BluetoothGATTDescriptorEmpty;
-#[cfg(feature = "bluetooth")]
+#[cfg(feature = "bluetooth-test")]
 use blurmock::fake_descriptor::FakeBluetoothGATTDescriptor;
 #[cfg(all(target_os = "linux", feature = "bluetooth"))]
 use blurz::bluetooth_gatt_service::BluetoothGATTService as BluetoothGATTServiceBluez;
@@ -40,7 +40,7 @@ use blurz::bluetooth_gatt_service::BluetoothGATTService as BluetoothGATTServiceB
 use blurdroid::bluetooth_gatt_service::Service as BluetoothGATTServiceAndroid;
 #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
 use empty::BluetoothGATTService as BluetoothGATTServiceEmpty;
-#[cfg(feature = "bluetooth")]
+#[cfg(feature = "bluetooth-test")]
 use blurmock::fake_service::FakeBluetoothGATTService;
 #[cfg(all(target_os = "linux", feature = "bluetooth"))]
 use blurz::bluetooth_discovery_session::BluetoothDiscoverySession as BluetoothDiscoverySessionBluez;
@@ -48,7 +48,7 @@ use blurz::bluetooth_discovery_session::BluetoothDiscoverySession as BluetoothDi
 use blurdroid::bluetooth_discovery_session::DiscoverySession as BluetoothDiscoverySessionAndroid;
 #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
 use empty::BluetoothDiscoverySession as BluetoothDiscoverySessionEmpty;
-#[cfg(feature = "bluetooth")]
+#[cfg(feature = "bluetooth-test")]
 use blurmock::fake_discovery_session::FakeBluetoothDiscoverySession;
 
 use std::sync::Arc;
@@ -64,7 +64,7 @@ pub enum BluetoothAdapter {
     Android(Arc<BluetoothAdapterAndroid>),
     #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
     Empty(Arc<BluetoothAdapterEmpty>),
-    #[cfg(feature = "bluetooth")]
+    #[cfg(feature = "bluetooth-test")]
     Mock(Arc<FakeBluetoothAdapter>),
 }
 
@@ -76,7 +76,7 @@ pub enum BluetoothDiscoverySession {
     Android(Arc<BluetoothDiscoverySessionAndroid>),
     #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
     Empty(Arc<BluetoothDiscoverySessionEmpty>),
-    #[cfg(feature = "bluetooth")]
+    #[cfg(feature = "bluetooth-test")]
     Mock(Arc<FakeBluetoothDiscoverySession>),
 }
 
@@ -88,7 +88,7 @@ pub enum BluetoothDevice {
     Android(Arc<BluetoothDeviceAndroid>),
     #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
     Empty(Arc<BluetoothDeviceEmpty>),
-    #[cfg(feature = "bluetooth")]
+    #[cfg(feature = "bluetooth-test")]
     Mock(Arc<FakeBluetoothDevice>),
 }
 
@@ -100,7 +100,7 @@ pub enum BluetoothGATTService {
     Android(Arc<BluetoothGATTServiceAndroid>),
     #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
     Empty(Arc<BluetoothGATTServiceEmpty>),
-    #[cfg(feature = "bluetooth")]
+    #[cfg(feature = "bluetooth-test")]
     Mock(Arc<FakeBluetoothGATTService>),
 }
 
@@ -112,7 +112,7 @@ pub enum BluetoothGATTCharacteristic {
     Android(Arc<BluetoothGATTCharacteristicAndroid>),
     #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
     Empty(Arc<BluetoothGATTCharacteristicEmpty>),
-    #[cfg(feature = "bluetooth")]
+    #[cfg(feature = "bluetooth-test")]
     Mock(Arc<FakeBluetoothGATTCharacteristic>),
 }
 
@@ -124,7 +124,7 @@ pub enum BluetoothGATTDescriptor {
     Android(Arc<BluetoothGATTDescriptorAndroid>),
     #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
     Empty(Arc<BluetoothGATTDescriptorEmpty>),
-    #[cfg(feature = "bluetooth")]
+    #[cfg(feature = "bluetooth-test")]
     Mock(Arc<FakeBluetoothGATTDescriptor>),
 }
 
@@ -137,7 +137,7 @@ macro_rules! get_inner_and_call(
             &$enum_type::Android(ref android) => android.$function_name(),
             #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
             &$enum_type::Empty(ref empty) => empty.$function_name(),
-            #[cfg(feature = "bluetooth")]
+            #[cfg(feature = "bluetooth-test")]
             &$enum_type::Mock(ref fake) => fake.$function_name(),
         }
     };
@@ -150,7 +150,7 @@ macro_rules! get_inner_and_call(
             &$enum_type::Android(ref android) => android.$function_name($value),
             #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
             &$enum_type::Empty(ref empty) => empty.$function_name($value),
-            #[cfg(feature = "bluetooth")]
+            #[cfg(feature = "bluetooth-test")]
             &$enum_type::Mock(ref fake) => fake.$function_name($value),
         }
     };
@@ -191,7 +191,7 @@ impl BluetoothAdapter {
         Ok(BluetoothAdapter::Empty(Arc::new(adapter)))
     }
 
-    #[cfg(feature = "bluetooth")]
+    #[cfg(feature = "bluetooth-test")]
     pub fn init_mock() -> Result<BluetoothAdapter, Box<Error>> {
         Ok(BluetoothAdapter::Mock(FakeBluetoothAdapter::new_empty()))
     }
@@ -200,7 +200,7 @@ impl BluetoothAdapter {
         get_inner_and_call!(self, BluetoothAdapter, get_id)
     }
 
-    #[cfg(feature = "bluetooth")]
+    #[cfg(feature = "bluetooth-test")]
     pub fn set_id(&self, id: String) {
         match self {
             &BluetoothAdapter::Mock(ref fake_adapter) => fake_adapter.set_id(id),
@@ -227,7 +227,7 @@ impl BluetoothAdapter {
         get_inner_and_call!(self, BluetoothAdapter, get_address)
     }
 
-    #[cfg(feature = "bluetooth")]
+    #[cfg(feature = "bluetooth-test")]
     pub fn set_address(&self, address: String) -> Result<(), Box<Error>> {
         match self {
             &BluetoothAdapter::Mock(ref fake_adapter) => fake_adapter.set_address(address),
@@ -239,7 +239,7 @@ impl BluetoothAdapter {
         get_inner_and_call!(self, BluetoothAdapter, get_name)
     }
 
-    #[cfg(feature = "bluetooth")]
+    #[cfg(feature = "bluetooth-test")]
     pub fn set_name(&self, name: String) -> Result<(), Box<Error>> {
         get_inner_and_call_test_func!(self, BluetoothAdapter, set_name, name)
     }
@@ -248,7 +248,7 @@ impl BluetoothAdapter {
         get_inner_and_call!(self, BluetoothAdapter, get_alias)
     }
 
-    #[cfg(feature = "bluetooth")]
+    #[cfg(feature = "bluetooth-test")]
     pub fn set_alias(&self, alias: String) -> Result<(), Box<Error>> {
         get_inner_and_call_test_func!(self, BluetoothAdapter, set_alias, alias)
     }
@@ -257,7 +257,7 @@ impl BluetoothAdapter {
         get_inner_and_call!(self, BluetoothAdapter, get_class)
     }
 
-    #[cfg(feature = "bluetooth")]
+    #[cfg(feature = "bluetooth-test")]
     pub fn set_class(&self, class: u32) -> Result<(), Box<Error>> {
         get_inner_and_call_test_func!(self, BluetoothAdapter, set_class, class)
     }
@@ -266,12 +266,12 @@ impl BluetoothAdapter {
         get_inner_and_call!(self, BluetoothAdapter, is_powered)
     }
 
-    #[cfg(feature = "bluetooth")]
+    #[cfg(feature = "bluetooth-test")]
     pub fn set_powered(&self, powered: bool) -> Result<(), Box<Error>> {
         get_inner_and_call_test_func!(self, BluetoothAdapter, set_powered, powered)
     }
 
-    #[cfg(feature = "bluetooth")]
+    #[cfg(feature = "bluetooth-test")]
     pub fn is_present(&self) -> Result<bool, Box<Error>> {
         match self {
             &BluetoothAdapter::Mock(ref fake_adapter) => fake_adapter.is_present(),
@@ -279,7 +279,7 @@ impl BluetoothAdapter {
         }
     }
 
-    #[cfg(feature = "bluetooth")]
+    #[cfg(feature = "bluetooth-test")]
     pub fn set_present(&self, present: bool) -> Result<(), Box<Error>> {
         get_inner_and_call_test_func!(self, BluetoothAdapter, set_present, present)
     }
@@ -288,7 +288,7 @@ impl BluetoothAdapter {
         get_inner_and_call!(self, BluetoothAdapter, is_discoverable)
     }
 
-    #[cfg(feature = "bluetooth")]
+    #[cfg(feature = "bluetooth-test")]
     pub fn set_discoverable(&self, discoverable: bool) -> Result<(), Box<Error>> {
         get_inner_and_call_test_func!(self, BluetoothAdapter, set_discoverable, discoverable)
     }
@@ -297,7 +297,7 @@ impl BluetoothAdapter {
         get_inner_and_call!(self, BluetoothAdapter, is_pairable)
     }
 
-    #[cfg(feature = "bluetooth")]
+    #[cfg(feature = "bluetooth-test")]
     pub fn set_pairable(&self, pairable: bool) -> Result<(), Box<Error>> {
         get_inner_and_call_test_func!(self, BluetoothAdapter, set_pairable, pairable)
     }
@@ -306,7 +306,7 @@ impl BluetoothAdapter {
         get_inner_and_call!(self, BluetoothAdapter, get_pairable_timeout)
     }
 
-    #[cfg(feature = "bluetooth")]
+    #[cfg(feature = "bluetooth-test")]
     pub fn set_pairable_timeout(&self, timeout: u32) -> Result<(), Box<Error>> {
         get_inner_and_call_test_func!(self, BluetoothAdapter, set_pairable_timeout, timeout)
     }
@@ -315,7 +315,7 @@ impl BluetoothAdapter {
         get_inner_and_call!(self, BluetoothAdapter, get_discoverable_timeout)
     }
 
-    #[cfg(feature = "bluetooth")]
+    #[cfg(feature = "bluetooth-test")]
     pub fn set_discoverable_timeout(&self, timeout: u32) -> Result<(), Box<Error>> {
         get_inner_and_call_test_func!(self, BluetoothAdapter, set_discoverable_timeout, timeout)
     }
@@ -324,17 +324,17 @@ impl BluetoothAdapter {
         get_inner_and_call!(self, BluetoothAdapter, is_discovering)
     }
 
-    #[cfg(feature = "bluetooth")]
+    #[cfg(feature = "bluetooth-test")]
     pub fn set_discovering(&self, discovering: bool) -> Result<(), Box<Error>> {
         get_inner_and_call_test_func!(self, BluetoothAdapter, set_discovering, discovering)
     }
 
-    #[cfg(feature = "bluetooth")]
+    #[cfg(feature = "bluetooth-test")]
     pub fn set_can_start_discovery(&self, can_start_discovery: bool) -> Result<(), Box<Error>> {
         get_inner_and_call_test_func!(self, BluetoothAdapter, set_can_start_discovery, can_start_discovery)
     }
 
-    #[cfg(feature = "bluetooth")]
+    #[cfg(feature = "bluetooth-test")]
     pub fn create_discovery_session(&self) -> Result<BluetoothDiscoverySession, Box<Error>> {
         BluetoothDiscoverySession::create_session(self.clone())
     }
@@ -343,7 +343,7 @@ impl BluetoothAdapter {
         get_inner_and_call!(self, BluetoothAdapter, get_uuids)
     }
 
-    #[cfg(feature = "bluetooth")]
+    #[cfg(feature = "bluetooth-test")]
     pub fn set_uuids(&self, uuids: Vec<String>) -> Result<(), Box<Error>> {
         get_inner_and_call_test_func!(self, BluetoothAdapter, set_uuids, uuids)
     }
@@ -368,7 +368,7 @@ impl BluetoothAdapter {
         get_inner_and_call!(self, BluetoothAdapter, get_modalias)
     }
 
-    #[cfg(feature = "bluetooth")]
+    #[cfg(feature = "bluetooth-test")]
     pub fn set_modalias(&self, modalias: String) -> Result<(), Box<Error>> {
         get_inner_and_call_test_func!(self, BluetoothAdapter, set_modalias, modalias)
     }
@@ -392,7 +392,7 @@ impl BluetoothDiscoverySession {
                 let empty_session = try!(BluetoothDiscoverySessionEmpty::create_session(adapter.get_adapter()));
                 Ok(BluetoothDiscoverySession::Empty(Arc::new(empty_session)))
             },
-            #[cfg(feature = "bluetooth")]
+            #[cfg(feature = "bluetooth-test")]
             BluetoothAdapter::Mock(fake_adapter) => {
                 let test_session = try!(FakeBluetoothDiscoverySession::create_session(fake_adapter));
                 Ok(BluetoothDiscoverySession::Mock(Arc::new(test_session)))
@@ -425,7 +425,7 @@ impl BluetoothDevice {
             BluetoothAdapter::Empty(adapter) => {
                 BluetoothDevice::Empty(Arc::new(BluetoothDeviceEmpty::new(device)))
             },
-            #[cfg(feature = "bluetooth")]
+            #[cfg(feature = "bluetooth-test")]
             BluetoothAdapter::Mock(fake_adapter) => {
                 BluetoothDevice::Mock(FakeBluetoothDevice::new_empty(fake_adapter, device))
             },
@@ -436,7 +436,7 @@ impl BluetoothDevice {
         get_inner_and_call!(self, BluetoothDevice, get_id)
     }
 
-    #[cfg(feature = "bluetooth")]
+    #[cfg(feature = "bluetooth-test")]
     pub fn set_id(&self, id: String) {
         match self {
             &BluetoothDevice::Mock(ref fake_device) => fake_device.set_id(id),
@@ -448,7 +448,7 @@ impl BluetoothDevice {
         get_inner_and_call!(self, BluetoothDevice, get_address)
     }
 
-    #[cfg(feature = "bluetooth")]
+    #[cfg(feature = "bluetooth-test")]
     pub fn set_address(&self, address: String) -> Result<(), Box<Error>> {
         get_inner_and_call_test_func!(self, BluetoothDevice, set_address, address)
     }
@@ -457,7 +457,7 @@ impl BluetoothDevice {
         get_inner_and_call!(self, BluetoothDevice, get_name)
     }
 
-    #[cfg(feature = "bluetooth")]
+    #[cfg(feature = "bluetooth-test")]
     pub fn set_name(&self, name: String) -> Result<(), Box<Error>> {
         get_inner_and_call_test_func!(self, BluetoothDevice, set_name, name)
     }
@@ -474,7 +474,7 @@ impl BluetoothDevice {
         get_inner_and_call!(self, BluetoothDevice, get_appearance)
     }
 
-    #[cfg(feature = "bluetooth")]
+    #[cfg(feature = "bluetooth-test")]
     pub fn set_appearance(&self, appearance: u16) -> Result<(), Box<Error>> {
         get_inner_and_call_test_func!(self, BluetoothDevice, set_appearance, appearance)
     }
@@ -483,7 +483,7 @@ impl BluetoothDevice {
         get_inner_and_call!(self, BluetoothDevice, get_uuids)
     }
 
-    #[cfg(feature = "bluetooth")]
+    #[cfg(feature = "bluetooth-test")]
     pub fn set_uuids(&self, uuids: Vec<String>) -> Result<(), Box<Error>> {
         get_inner_and_call_test_func!(self, BluetoothDevice, set_uuids, uuids)
     }
@@ -496,12 +496,12 @@ impl BluetoothDevice {
         get_inner_and_call!(self, BluetoothDevice, is_connected)
     }
 
-    #[cfg(feature = "bluetooth")]
+    #[cfg(feature = "bluetooth-test")]
     pub fn is_connectable(&self) -> Result<bool, Box<Error>> {
         get_inner_and_call_test_func!(self, BluetoothDevice, is_connectable)
     }
 
-    #[cfg(feature = "bluetooth")]
+    #[cfg(feature = "bluetooth-test")]
     pub fn set_connectable(&self, connectable: bool) -> Result<(), Box<Error>> {
         get_inner_and_call_test_func!(self, BluetoothDevice, set_connectable, connectable)
     }
@@ -518,7 +518,7 @@ impl BluetoothDevice {
         get_inner_and_call!(self, BluetoothDevice, get_alias)
     }
 
-    #[cfg(feature = "bluetooth")]
+    #[cfg(feature = "bluetooth-test")]
     pub fn set_alias(&self, alias: String) -> Result<(), Box<Error>> {
         get_inner_and_call_test_func!(self, BluetoothDevice, set_alias, alias)
     }
@@ -600,7 +600,7 @@ impl BluetoothGATTService {
             BluetoothDevice::Empty(device) => {
                 BluetoothGATTService::Empty(Arc::new(BluetoothGATTServiceEmpty::new(service)))
             },
-            #[cfg(feature = "bluetooth")]
+            #[cfg(feature = "bluetooth-test")]
             BluetoothDevice::Mock(fake_device) => {
                 BluetoothGATTService::Mock(FakeBluetoothGATTService::new_empty(fake_device, service))
             },
@@ -615,7 +615,7 @@ impl BluetoothGATTService {
         get_inner_and_call!(self, BluetoothGATTService, get_uuid)
     }
 
-    #[cfg(feature = "bluetooth")]
+    #[cfg(feature = "bluetooth-test")]
     pub fn set_uuid(&self, uuid: String) -> Result<(), Box<Error>> {
         match self {
             &BluetoothGATTService::Mock(ref fake_service) => fake_service.set_uuid(uuid),
@@ -627,7 +627,7 @@ impl BluetoothGATTService {
         get_inner_and_call!(self, BluetoothGATTService, is_primary)
     }
 
-    #[cfg(feature = "bluetooth")]
+    #[cfg(feature = "bluetooth-test")]
     pub fn set_primary(&self, primary: bool) -> Result<(), Box<Error>> {
         get_inner_and_call_test_func!(self, BluetoothGATTService, set_is_primary, primary)
     }
@@ -658,7 +658,7 @@ impl BluetoothGATTCharacteristic {
             BluetoothGATTService::Empty(service) => {
                 BluetoothGATTCharacteristic::Empty(Arc::new(BluetoothGATTCharacteristicEmpty::new(characteristic)))
             },
-            #[cfg(feature = "bluetooth")]
+            #[cfg(feature = "bluetooth-test")]
             BluetoothGATTService::Mock(fake_service) => {
                 BluetoothGATTCharacteristic::Mock(FakeBluetoothGATTCharacteristic::new_empty(fake_service, characteristic))
             },
@@ -673,7 +673,7 @@ impl BluetoothGATTCharacteristic {
         get_inner_and_call!(self, BluetoothGATTCharacteristic, get_uuid)
     }
 
-    #[cfg(feature = "bluetooth")]
+    #[cfg(feature = "bluetooth-test")]
     pub fn set_uuid(&self, uuid: String) -> Result<(), Box<Error>> {
         get_inner_and_call_test_func!(self, BluetoothGATTCharacteristic, set_uuid, uuid)
     }
@@ -727,7 +727,7 @@ impl BluetoothGATTDescriptor {
             BluetoothGATTCharacteristic::Empty(characteristic) => {
                 BluetoothGATTDescriptor::Empty(Arc::new(BluetoothGATTDescriptorEmpty::new(descriptor)))
             },
-            #[cfg(feature = "bluetooth")]
+            #[cfg(feature = "bluetooth-test")]
             BluetoothGATTCharacteristic::Mock(fake_characteristic) => {
                 BluetoothGATTDescriptor::Mock(FakeBluetoothGATTDescriptor::new_empty(fake_characteristic, descriptor))
             },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,9 +6,9 @@
 extern crate blurz;
 #[cfg(all(target_os = "android", feature = "bluetooth"))]
 extern crate blurdroid;
-#[cfg(feature = "bluetooth-test")]
+#[cfg(feature = "bluetooth")]
 extern crate blurmock;
 
 pub mod bluetooth;
-#[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"), feature = "bluetooth-test")))]
+#[cfg(not(any(all(target_os = "linux", feature = "bluetooth"), all(target_os = "android", feature = "bluetooth"))))]
 mod empty;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 extern crate blurz;
 #[cfg(all(target_os = "android", feature = "bluetooth"))]
 extern crate blurdroid;
-#[cfg(feature = "bluetooth")]
+#[cfg(feature = "bluetooth-test")]
 extern crate blurmock;
 
 pub mod bluetooth;


### PR DESCRIPTION
1. The structs are replaced with enums, to allow the usage of multiple GATT  types (a mock and a platform specific) at the same time. 
2. Using two macros (one for the default functions, and one for the test functions) to make the code size shorter.
3. The `get_includes` service function has been refactored, do to the missing device attribute in the new `BluetoothService` enum types. Now it needs a `Bluetoothdevice` type as a parameter.
4. The `bluetooth-test` feature is optional and can build in pair with a platform specific configuration.
